### PR TITLE
Merge Paperlib Additions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,7 @@ repositories {
     maven("https://repo.glaremasters.me/repository/towny/") // Towny
     maven("https://repo.oraxen.com/releases") // Oraxen
     maven("https://storehouse.okaeri.eu/repository/maven-public/") // Okaeri Config
-    maven("https://papermc.io/repo/repository/maven-public/")
+    maven("https://papermc.io/repo/repository/maven-public/") // PaperLib
 }
 
 dependencies {
@@ -58,7 +58,7 @@ dependencies {
     compileOnly("org.spigotmc:spigot-api:1.20.2-R0.1-SNAPSHOT") {
         exclude("com.google.code.gson", "gson") // Implemented manually
     }
-    // Paper Lib
+    // Paper Lib, performance improvements on Paper based servers and async teleporting on Folia
     implementation("io.papermc:paperlib:1.0.8")
 
     // Implemented manually mainly due to older server versions implementing versions of GSON
@@ -212,7 +212,6 @@ publishing {
 
 	publications {
         if (user == null || pass == null) {
-            println("No repository credentials found, skipping publication")
             return@publications
         }
         create<MavenPublication>("maven") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ val langVersion = 17
 val encoding = "UTF-8"
 
 group = "com.dre.brewery"
-version = "3.4.3"
+version = "3.4.4-SNAPSHOT"
 
 repositories {
     mavenCentral()
@@ -50,6 +50,7 @@ repositories {
     maven("https://repo.glaremasters.me/repository/towny/") // Towny
     maven("https://repo.oraxen.com/releases") // Oraxen
     maven("https://storehouse.okaeri.eu/repository/maven-public/") // Okaeri Config
+    maven("https://papermc.io/repo/repository/maven-public/")
 }
 
 dependencies {
@@ -57,6 +58,9 @@ dependencies {
     compileOnly("org.spigotmc:spigot-api:1.20.2-R0.1-SNAPSHOT") {
         exclude("com.google.code.gson", "gson") // Implemented manually
     }
+    // Paper Lib
+    implementation("io.papermc:paperlib:1.0.8")
+
     // Implemented manually mainly due to older server versions implementing versions of GSON
     // Which don't support records.
     implementation("com.google.code.gson:gson:2.11.0")
@@ -114,7 +118,7 @@ tasks {
 
     build {
         dependsOn(shadowJar)
-        finalizedBy("kotlinReducedJar")
+        //finalizedBy("kotlinReducedJar")
     }
 
     jar {
@@ -141,6 +145,7 @@ tasks {
         relocate("com.github.Anon8281.universalScheduler", "com.dre.brewery.depend.universalScheduler")
         relocate("eu.okaeri", "com.dre.brewery.depend.okaeri")
         relocate("com.mongodb", "com.dre.brewery.depend.mongodb")
+        relocate("io.papermc.lib", "com.dre.brewery.depend.paperlib")
 
         archiveClassifier.set("")
     }

--- a/src/main/java/com/dre/brewery/BDistiller.java
+++ b/src/main/java/com/dre/brewery/BDistiller.java
@@ -25,6 +25,7 @@ import com.dre.brewery.utility.Logging;
 import com.dre.brewery.utility.MinecraftVersion;
 import com.github.Anon8281.universalScheduler.UniversalRunnable;
 import com.github.Anon8281.universalScheduler.scheduling.tasks.MyScheduledTask;
+import io.papermc.lib.PaperLib;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
@@ -73,17 +74,17 @@ public class BDistiller {
 	}
 
 	public static void distillerClick(InventoryClickEvent event) {
-		BrewerInventory standInv = (BrewerInventory) event.getInventory();
-		final Block standBlock = standInv.getHolder().getBlock();
+		BrewingStand standInv = (BrewingStand) PaperLib.getHolder(event.getInventory(), true).getHolder();
+		final Block standBlock = standInv.getBlock();
 
 		// If we were already tracking the brewer, cancel any ongoing event due to the click.
 		BDistiller distiller = trackedDistillers.get(standBlock);
 		if (distiller != null) {
 			distiller.cancelDistill();
-			standInv.getHolder().setBrewingTime(0); // Fixes brewing continuing without fuel for normal potions
-			standInv.getHolder().update();
+			standInv.setBrewingTime(0); // Fixes brewing continuing without fuel for normal potions
+			standInv.update();
 		}
-		final int fuel = standInv.getHolder().getFuelLevel();
+		final int fuel = standInv.getFuelLevel();
 
 		// Now check if we should bother to track it.
 		distiller = new BDistiller(standBlock, fuel);

--- a/src/main/java/com/dre/brewery/BDistiller.java
+++ b/src/main/java/com/dre/brewery/BDistiller.java
@@ -28,7 +28,6 @@ import com.github.Anon8281.universalScheduler.scheduling.tasks.MyScheduledTask;
 import io.papermc.lib.PaperLib;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockState;
 import org.bukkit.block.BrewingStand;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.BrewerInventory;
@@ -205,7 +204,7 @@ public class BDistiller {
 					return;
 				}
 
-				BrewingStand stand = (BrewingStand) standBlock.getState();
+				BrewingStand stand = (BrewingStand) PaperLib.getBlockState(standBlock, true).getState();
 				if (brewTime == -1 && !prepareForDistillables(stand)) { // check at the beginning for distillables
 					return;
 				}

--- a/src/main/java/com/dre/brewery/BPlayer.java
+++ b/src/main/java/com/dre/brewery/BPlayer.java
@@ -34,6 +34,7 @@ import com.dre.brewery.utility.Logging;
 import com.dre.brewery.utility.MinecraftVersion;
 import com.dre.brewery.utility.PermissionUtil;
 import com.github.Anon8281.universalScheduler.scheduling.tasks.MyScheduledTask;
+import io.papermc.lib.PaperLib;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -538,7 +539,7 @@ public class BPlayer {
 			if (config.isEnableWake() && !player.hasPermission("brewery.bypass.teleport")) {
 				Location randomLoc = Wakeup.getRandom(player.getLocation());
 				if (randomLoc != null) {
-					player.teleport(randomLoc);
+					PaperLib.teleportAsync(player, randomLoc);
 					lang.sendEntry(player, "Player_Wake");
 				}
 			}
@@ -553,20 +554,21 @@ public class BPlayer {
 
 	public void goHome(final Player player) {
 		String homeType = config.getHomeType();
-		if (homeType != null) {
-			Location home = null;
-			if (homeType.equalsIgnoreCase("bed")) {
-				home = player.getBedSpawnLocation();
-			} else if (homeType.startsWith("cmd: ")) {
-				player.performCommand(homeType.substring(5));
-			} else if (homeType.startsWith("cmd:")) {
-				player.performCommand(homeType.substring(4));
-			} else {
-				Logging.errorLog("Config.yml 'homeType: " + homeType + "' unknown!");
-			}
-			if (home != null) {
-				player.teleport(home);
-			}
+		if (homeType == null) {
+			return;
+		}
+		if (homeType.equalsIgnoreCase("bed")) {
+			PaperLib.getBedSpawnLocationAsync(player, true).thenAcceptAsync(it -> {
+				if (it != null) {
+					PaperLib.teleportAsync(player, it);
+				}
+			});
+		} else if (homeType.startsWith("cmd: ")) {
+			player.performCommand(homeType.substring(5));
+		} else if (homeType.startsWith("cmd:")) {
+			player.performCommand(homeType.substring(4));
+		} else {
+			Logging.errorLog("Config.yml 'homeType: " + homeType + "' unknown!");
 		}
 	}
 

--- a/src/main/java/com/dre/brewery/BSealer.java
+++ b/src/main/java/com/dre/brewery/BSealer.java
@@ -132,7 +132,7 @@ public class BSealer implements InventoryHolder {
 
 	public static boolean isBSealer(Block block) {
 		if (BreweryPlugin.getMCVersion().isOrLater(MinecraftVersion.V1_14) && block.getType() == config.getSealingTableBlock()) {
-			Container container = (Container) block.getState();
+			Container container = (Container) PaperLib.getBlockState(block, true).getState();
 			if (container.getCustomName() != null) {
 				if (container.getCustomName().equals("§e" + lang.getEntry("Etc_SealingTable"))) {
 					return true;
@@ -150,7 +150,7 @@ public class BSealer implements InventoryHolder {
 			assert itemMeta != null;
 			if ((itemMeta.hasDisplayName() && itemMeta.getDisplayName().equals("§e" + lang.getEntry("Etc_SealingTable"))) ||
 				itemMeta.getPersistentDataContainer().has(BSealer.TAG_KEY, PersistentDataType.BYTE)) {
-				Container container = (Container) block.getState();
+				Container container = (Container) PaperLib.getBlockState(block, true).getState();
 				// Rotate the Block 180° so it looks different
 				if (container.getBlockData() instanceof Directional dir) {
 					dir.setFacing(dir.getFacing().getOppositeFace());

--- a/src/main/java/com/dre/brewery/BSealer.java
+++ b/src/main/java/com/dre/brewery/BSealer.java
@@ -25,6 +25,7 @@ import com.dre.brewery.configuration.files.Config;
 import com.dre.brewery.configuration.files.Lang;
 import com.dre.brewery.utility.MinecraftVersion;
 import com.github.Anon8281.universalScheduler.scheduling.tasks.MyScheduledTask;
+import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -61,16 +62,16 @@ public class BSealer implements InventoryHolder {
 	public BSealer(Player player) {
 		this.player = player;
 		if (inventoryHolderWorking) {
-			Inventory inv = BreweryPlugin.getInstance().getServer().createInventory(this, InventoryType.DISPENSER, lang.getEntry("Etc_SealingTable"));
+			Inventory inv = Bukkit.createInventory(this, InventoryType.DISPENSER, lang.getEntry("Etc_SealingTable"));
 			// Inventory Holder (for DISPENSER, ...) is only passed in Paper, not in Spigot. Doing inventory.getHolder() will return null in spigot :/
-			if (inv.getHolder() == this) {
+			if (PaperLib.getHolder(inv, true).getHolder() == this) {
 				inventory = inv;
 				return;
 			} else {
 				inventoryHolderWorking = false;
 			}
 		}
-		inventory = BreweryPlugin.getInstance().getServer().createInventory(this, 9, lang.getEntry("Etc_SealingTable"));
+		inventory = Bukkit.createInventory(this, 9, lang.getEntry("Etc_SealingTable"));
 	}
 
 	@Override

--- a/src/main/java/com/dre/brewery/Barrel.java
+++ b/src/main/java/com/dre/brewery/Barrel.java
@@ -33,6 +33,7 @@ import com.dre.brewery.lore.BrewLore;
 import com.dre.brewery.utility.BUtil;
 import com.dre.brewery.utility.BoundingBox;
 import com.dre.brewery.utility.Logging;
+import com.dre.brewery.utility.MinecraftVersion;
 import com.github.Anon8281.universalScheduler.UniversalRunnable;
 import lombok.Getter;
 import lombok.Setter;
@@ -469,7 +470,7 @@ public class Barrel extends BarrelBody implements InventoryHolder {
 	 * is this a Small barrel?
 	 */
 	public boolean isSmall() {
-		if (!BreweryPlugin.isFolia()) {
+		if (!MinecraftVersion.isFolia()) {
 			return BarrelAsset.isBarrelAsset(BarrelAsset.SIGN, spigot.getType());
 		}
 

--- a/src/main/java/com/dre/brewery/BarrelWoodType.java
+++ b/src/main/java/com/dre/brewery/BarrelWoodType.java
@@ -41,7 +41,7 @@ public enum BarrelWoodType {
     MANGROVE("Mangrove", 9),
     CHERRY("Cherry", 10),
     BAMBOO("Bamboo", 11),
-    CUT_COPPER("Cut Copper", 12, Material.CUT_COPPER, Material.CUT_COPPER_STAIRS, null, null),
+    CUT_COPPER("Cut Copper", 12, Material.CUT_COPPER, Material.CUT_COPPER_STAIRS),
     PALE_OAK("Pale Oak", 13),
     // If you're adding more wood types, add them above 'NONE'
     NONE("None", -1, true);
@@ -65,7 +65,6 @@ public enum BarrelWoodType {
 		}
     }
 
-
 	BarrelWoodType(String formattedName, int index, Material planks, Material stairs, Material sign, Material fence) {
 		this.formattedName = formattedName;
 		this.index = index;
@@ -75,6 +74,14 @@ public enum BarrelWoodType {
 		BarrelAsset.addBarrelAsset(BarrelAsset.SIGN, sign);
 		BarrelAsset.addBarrelAsset(BarrelAsset.FENCE, fence);
 	}
+
+    BarrelWoodType(String formattedName, int index, Material planks, Material stairs) {
+        this.formattedName = formattedName;
+        this.index = index;
+
+        BarrelAsset.addBarrelAsset(BarrelAsset.PLANKS, planks);
+        BarrelAsset.addBarrelAsset(BarrelAsset.STAIRS, stairs);
+    }
 
 	@Nullable
 	private Material[] getStandardBarrelAssetMaterial(BarrelAsset assetType) {

--- a/src/main/java/com/dre/brewery/Brew.java
+++ b/src/main/java/com/dre/brewery/Brew.java
@@ -146,7 +146,7 @@ public class Brew implements Cloneable {
 	 */
 	@Nullable
 	public static Brew get(ItemMeta meta) {
-		if (!BreweryPlugin.isUseNBT() && !meta.hasLore()) return null;
+		if (!MinecraftVersion.isUseNBT() && !meta.hasLore()) return null;
 
 		Brew brew = load(meta);
 
@@ -170,7 +170,7 @@ public class Brew implements Cloneable {
 
 		ItemMeta meta = item.getItemMeta();
 		assert meta != null;
-		if (!BreweryPlugin.isUseNBT() && !meta.hasLore()) return null;
+		if (!MinecraftVersion.isUseNBT() && !meta.hasLore()) return null;
 
 		Brew brew = load(meta);
 
@@ -183,7 +183,7 @@ public class Brew implements Cloneable {
 			item.setItemMeta(meta);
 		} else if (brew != null && brew.needsSave) {
 			// Brew needs saving from a previous format
-			if (BreweryPlugin.isUseNBT()) {
+			if (MinecraftVersion.isUseNBT()) {
 				new BrewLore(brew, (PotionMeta) meta).removeLoreData();
 				Logging.debugLog("removed Data from Lore");
 			}
@@ -853,9 +853,9 @@ public class Brew implements Cloneable {
 
 		ItemMeta meta = item.getItemMeta();
 		assert meta != null;
-		if (!BreweryPlugin.isUseNBT() && !meta.hasLore()) return false;
+		if (!MinecraftVersion.isUseNBT() && !meta.hasLore()) return false;
 
-		if (BreweryPlugin.isUseNBT()) {
+		if (MinecraftVersion.isUseNBT()) {
 			// Check for Data on PersistentDataContainer
 			if (NBTLoadStream.hasDataInMeta(meta)) {
 				return true;
@@ -871,7 +871,7 @@ public class Brew implements Cloneable {
 
 	private static Brew load(ItemMeta meta) {
 		InputStream itemLoadStream = null;
-		if (BreweryPlugin.isUseNBT()) {
+		if (MinecraftVersion.isUseNBT()) {
 			// Try loading the Item Data from PersistentDataContainer
 			NBTLoadStream nbtStream = new NBTLoadStream(meta);
 			if (nbtStream.hasData()) {
@@ -921,7 +921,7 @@ public class Brew implements Cloneable {
 				// We have either enabled encode and the data was not encoded or the other way round
 				Logging.debugLog("Converting Brew to new encode setting");
 				brew.setNeedsSave(true);
-			} else if (BreweryPlugin.isUseNBT() && itemLoadStream instanceof Base91DecoderStream) {
+			} else if (MinecraftVersion.isUseNBT() && itemLoadStream instanceof Base91DecoderStream) {
 				// We are on a version that supports nbt but the data is still in the lore of the item
 				// Just save it again so that it gets saved to nbt
 				Logging.debugLog("Converting Brew to NBT");
@@ -968,7 +968,7 @@ public class Brew implements Cloneable {
 	 */
 	public void save(ItemMeta meta) {
 		OutputStream itemSaveStream;
-		if (BreweryPlugin.isUseNBT()) {
+		if (MinecraftVersion.isUseNBT()) {
 			itemSaveStream = new NBTSaveStream(meta);
 		} else {
 			itemSaveStream = new Base91EncoderStream(new LoreSaveStream(meta, 0));

--- a/src/main/java/com/dre/brewery/BreweryPlugin.java
+++ b/src/main/java/com/dre/brewery/BreweryPlugin.java
@@ -54,6 +54,7 @@ import com.dre.brewery.utility.NBTUtil;
 import com.dre.brewery.utility.UpdateChecker;
 import com.github.Anon8281.universalScheduler.UniversalScheduler;
 import com.github.Anon8281.universalScheduler.scheduling.schedulers.TaskScheduler;
+import io.papermc.lib.PaperLib;
 import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.Bukkit;
@@ -83,8 +84,6 @@ public class BreweryPlugin extends JavaPlugin {
 	private @Getter static BreweryPlugin instance;
 	private @Getter static MinecraftVersion MCVersion;
 	private @Getter @Setter static DataManager dataManager;
-	private @Getter static boolean isFolia = false;
-	private @Getter static boolean useNBT = false;
 
 
 	private final Map<String, Function<ItemLoader, Ingredient>> ingredientLoaders = new HashMap<>(); // Registrations
@@ -104,21 +103,8 @@ public class BreweryPlugin extends JavaPlugin {
 
 	@Override
 	public void onEnable() {
-		try {
-			Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
-			isFolia = true;
-		} catch (ClassNotFoundException ignored) {}
-
-
-		// MC 1.13 uses a different NBT API than the newer versions.
-		// We decide here which to use, the new or the old or none at all
-		if (NBTUtil.initNbt()) {
-			useNBT = true;
-		}
-
 		if (getMCVersion().isOrLater(MinecraftVersion.V1_14)) {
-			// Campfires are weird
-			// Initialize once now so it doesn't lag later when we check for campfires under Cauldrons
+			// Campfires are weird, Initialize once now so it doesn't lag later when we check for campfires under Cauldrons
 			getServer().createBlockData(Material.CAMPFIRE);
 		}
 
@@ -222,6 +208,10 @@ public class BreweryPlugin extends JavaPlugin {
 		}
 
 		Logging.log("Using scheduler&7: &a" + scheduler.getClass().getSimpleName());
+		Logging.log("Environment&7: &a" + Logging.getEnvironmentAsString());
+		if (!PaperLib.isPaper()) {
+			Logging.log("&aBreweryX performs best on Paper-based servers. Please consider switching to Paper for the best experience. &7(https://papermc.io/)");
+		}
 		Logging.log("BreweryX enabled!");
 	}
 

--- a/src/main/java/com/dre/brewery/BreweryPlugin.java
+++ b/src/main/java/com/dre/brewery/BreweryPlugin.java
@@ -210,7 +210,7 @@ public class BreweryPlugin extends JavaPlugin {
 		Logging.log("Using scheduler&7: &a" + scheduler.getClass().getSimpleName());
 		Logging.log("Environment&7: &a" + Logging.getEnvironmentAsString());
 		if (!PaperLib.isPaper()) {
-			Logging.log("&aBreweryX performs best on Paper-based servers. Please consider switching to Paper for the best experience. &7(https://papermc.io/)");
+			Logging.log("&aBreweryX performs best on Paper-based servers. Please consider switching to Paper for the best experience. &7https://papermc.io");
 		}
 		Logging.log("BreweryX enabled!");
 	}

--- a/src/main/java/com/dre/brewery/MCBarrel.java
+++ b/src/main/java/com/dre/brewery/MCBarrel.java
@@ -24,6 +24,7 @@ import com.dre.brewery.configuration.ConfigManager;
 import com.dre.brewery.configuration.files.Config;
 import com.dre.brewery.configuration.files.Lang;
 import com.dre.brewery.utility.Logging;
+import io.papermc.lib.PaperLib;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Barrel;
@@ -61,9 +62,8 @@ public class MCBarrel {
 	// Now Opening this Barrel for a player
 	public void open() {
 		// if nobody had the inventory opened
-		if (inv.getViewers().size() == 1 && inv.getHolder() instanceof org.bukkit.block.Barrel) {
-			Barrel barrel = (Barrel) inv.getHolder();
-			PersistentDataContainer data = barrel.getPersistentDataContainer();
+		if (inv.getViewers().size() == 1 && PaperLib.getHolder(inv, true).getHolder() instanceof Barrel barrel) {
+            PersistentDataContainer data = barrel.getPersistentDataContainer();
 			NamespacedKey key = new NamespacedKey(BreweryPlugin.getInstance(), TAG);
 			if (!data.has(key, PersistentDataType.LONG)) {
 				key = new NamespacedKey("brewery", TAG.toLowerCase()); // Legacy key
@@ -115,8 +115,7 @@ public class MCBarrel {
 				if (item != null) {
 					if (Brew.isBrew(item)) {
 						// We found a brew, so set time on this Barrel
-						if (inv.getHolder() instanceof org.bukkit.block.Barrel) {
-							Barrel barrel = (Barrel) inv.getHolder();
+						if (PaperLib.getHolder(inv, true).getHolder() instanceof org.bukkit.block.Barrel barrel) {
 							PersistentDataContainer data = barrel.getPersistentDataContainer();
 							data.set(new NamespacedKey(BreweryPlugin.getInstance(), TAG), PersistentDataType.LONG, mcBarrelTime);
 							barrel.update();

--- a/src/main/java/com/dre/brewery/Wakeup.java
+++ b/src/main/java/com/dre/brewery/Wakeup.java
@@ -24,6 +24,7 @@ import com.dre.brewery.configuration.ConfigManager;
 import com.dre.brewery.configuration.files.Lang;
 import com.dre.brewery.utility.BUtil;
 import com.dre.brewery.utility.Logging;
+import io.papermc.lib.PaperLib;
 import lombok.Getter;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -192,7 +193,7 @@ public class Wakeup {
 
 				Wakeup wakeup = wakeups.get(id);
 				if (wakeup.check()) {
-					player.teleport(wakeup.loc);
+					PaperLib.teleportAsync(player, wakeup.loc);
 				} else {
 					String world = wakeup.loc.getWorld().getName();
 					int x = (int) wakeup.loc.getX();
@@ -245,7 +246,7 @@ public class Wakeup {
 
 		if (wakeup.check()) {
 			lang.sendEntry(checkPlayer, "Player_WakeTeleport", checkId, world, "" + x , "" + y, "" + z);
-			checkPlayer.teleport(wakeup.loc);
+			PaperLib.teleportAsync(checkPlayer, wakeup.loc);
 		} else {
 			lang.sendEntry(checkPlayer, "Player_WakeFilled", checkId, world, "" + x , "" + y, "" + z);
 		}

--- a/src/main/java/com/dre/brewery/api/addons/BreweryAddon.java
+++ b/src/main/java/com/dre/brewery/api/addons/BreweryAddon.java
@@ -24,6 +24,7 @@ import com.dre.brewery.BreweryPlugin;
 import com.dre.brewery.commands.CommandManager;
 import com.dre.brewery.utility.MinecraftVersion;
 import com.github.Anon8281.universalScheduler.scheduling.schedulers.TaskScheduler;
+import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
@@ -72,7 +73,6 @@ import java.util.List;
 @SuppressWarnings("unused")
 public abstract class BreweryAddon {
 
-	private static final boolean isPaper;
 	private final List<Listener> listeners = new ArrayList<>();
 	private final List<String> commands = new ArrayList<>();
 
@@ -236,7 +236,7 @@ public abstract class BreweryAddon {
 	 * @return true if running on Folia, false otherwise.
 	 */
 	public boolean isFolia() {
-		return BreweryPlugin.isFolia();
+		return MinecraftVersion.isFolia();
 	}
 
 	/**
@@ -244,18 +244,6 @@ public abstract class BreweryAddon {
 	 * @return true if running on Paper, false otherwise.
 	 */
 	public boolean isPaper() {
-		return isPaper;
-	}
-
-
-	static {
-		boolean tempBool;
-		try {
-			Class.forName("com.destroystokyo.paper.ParticleBuilder");
-			tempBool = true;
-		} catch (ClassNotFoundException ignored) {
-			tempBool = false;
-		}
-		isPaper = tempBool;
+		return PaperLib.isPaper();
 	}
 }

--- a/src/main/java/com/dre/brewery/configuration/files/Lang.java
+++ b/src/main/java/com/dre/brewery/configuration/files/Lang.java
@@ -59,7 +59,7 @@ public class Lang extends AbstractOkaeriConfigFile {
 
     public void mapStrings() {
         BreweryPlugin plugin = BreweryPlugin.getInstance();
-        Logging.log("Using language&7: &6" + this.getBindFile().getFileName());
+        Logging.log("Using language&7: &a" + this.getBindFile().getFileName());
 
         this.mappedEntries = new HashMap<>();
         for (Field field : this.getClass().getDeclaredFields()) {

--- a/src/main/java/com/dre/brewery/integration/listeners/IntegrationListener.java
+++ b/src/main/java/com/dre/brewery/integration/listeners/IntegrationListener.java
@@ -45,6 +45,7 @@ import com.dre.brewery.utility.MaterialUtil;
 import com.dre.brewery.utility.Logging;
 import com.dre.brewery.utility.MinecraftVersion;
 import io.lumine.mythic.lib.api.item.NBTItem;
+import io.papermc.lib.PaperLib;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -320,14 +321,15 @@ public class IntegrationListener implements Listener {
 
 	@EventHandler
 	public void onInventoryClose(InventoryCloseEvent event) {
-		if (Hook.LOGBLOCK.isEnabled()) {
-			if (event.getInventory().getHolder() instanceof Barrel) {
-				try {
-					LogBlockBarrel.closeBarrel(event.getPlayer(), event.getInventory());
-				} catch (Exception e) {
-					Logging.errorLog("Failed to Log Barrel to LogBlock!", e);
-					Logging.errorLog("Brewery was tested with version 1.94 of LogBlock!");
-				}
+		if (!Hook.LOGBLOCK.isEnabled()) {
+			return;
+		}
+		if (PaperLib.getHolder(event.getInventory(), true).getHolder() instanceof Barrel) {
+			try {
+				LogBlockBarrel.closeBarrel(event.getPlayer(), event.getInventory());
+			} catch (Exception e) {
+				Logging.errorLog("Failed to Log Barrel to LogBlock!", e);
+				Logging.errorLog("Brewery was tested with version 1.94 of LogBlock!");
 			}
 		}
 	}

--- a/src/main/java/com/dre/brewery/integration/listeners/IntegrationListener.java
+++ b/src/main/java/com/dre/brewery/integration/listeners/IntegrationListener.java
@@ -227,7 +227,7 @@ public class IntegrationListener implements Listener {
 
 		if (config.isUseVirtualChestPerms()) {
 			Player player = event.getPlayer();
-			BlockState originalBlockState = event.getClickedBlock().getState();
+			BlockState originalBlockState = PaperLib.getBlockState(event.getClickedBlock(), true).getState();
 
 			event.getClickedBlock().setType(Material.CHEST, false);
 			PlayerInteractEvent simulatedEvent = new PlayerInteractEvent(

--- a/src/main/java/com/dre/brewery/listeners/CauldronListener.java
+++ b/src/main/java/com/dre/brewery/listeners/CauldronListener.java
@@ -22,6 +22,7 @@ package com.dre.brewery.listeners;
 
 import com.dre.brewery.BCauldron;
 import com.dre.brewery.utility.MaterialUtil;
+import io.papermc.lib.PaperLib;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
@@ -47,7 +48,7 @@ public class CauldronListener implements Listener {
 		}
 
 		Material currentType = event.getBlock().getType();
-		BlockState newState = event.getNewState();
+		BlockState newState = event.getNewState(); // Don't think PaperLib can be used here
 		Material newType = newState.getType();
 
 		if (currentType == Material.WATER_CAULDRON) {

--- a/src/main/java/com/dre/brewery/listeners/InventoryListener.java
+++ b/src/main/java/com/dre/brewery/listeners/InventoryListener.java
@@ -26,7 +26,9 @@ import com.dre.brewery.configuration.files.Config;
 import com.dre.brewery.lore.BrewLore;
 import com.dre.brewery.utility.Logging;
 import com.dre.brewery.utility.MinecraftVersion;
+import io.papermc.lib.PaperLib;
 import org.bukkit.Material;
+import org.bukkit.block.BrewingStand;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -161,11 +163,14 @@ public class InventoryListener implements Listener {
 	// convert to non colored Lore when taking out of Barrel/Brewer
 	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onInventoryClick(InventoryClickEvent event) {
-		if (event.getInventory().getType() == InventoryType.BREWING) {
+		Inventory inv = event.getInventory();
+		if (inv.getType() == InventoryType.BREWING) {
 			if (event.getSlot() > 2) {
 				return;
 			}
-		} else if (!(event.getInventory().getHolder() instanceof Barrel) && !(VERSION.isOrLater(MinecraftVersion.V1_14) && event.getInventory().getHolder() instanceof org.bukkit.block.Barrel)) {
+		}
+		InventoryHolder holder = PaperLib.getHolder(inv, true).getHolder();
+		if (!(holder instanceof Barrel) && !(VERSION.isOrLater(MinecraftVersion.V1_14) && holder instanceof org.bukkit.block.Barrel)) {
 			return;
 		}
 
@@ -222,7 +227,7 @@ public class InventoryListener implements Listener {
 	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void onInventoryClickBSealer(InventoryClickEvent event) {
 		if (VERSION.isOrEarlier(MinecraftVersion.V1_13)) return;
-		InventoryHolder holder = event.getInventory().getHolder();
+		InventoryHolder holder = PaperLib.getHolder(event.getInventory(), true).getHolder();
 		if (!(holder instanceof BSealer)) {
 			return;
 		}
@@ -284,8 +289,8 @@ public class InventoryListener implements Listener {
 	// Convert Color Lore from MC Barrels back into normal color on taking out
 	@EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
 	public void onHopperMove(InventoryMoveItemEvent event){
-		if (event.getSource() instanceof BrewerInventory) {
-			if (BDistiller.isTrackingDistiller(((BrewerInventory) event.getSource()).getHolder().getBlock())) {
+		if (event.getSource() instanceof BrewerInventory inv && PaperLib.getHolder(inv, true).getHolder() instanceof BrewingStand holder) {
+			if (BDistiller.isTrackingDistiller(holder.getBlock())) {
 				event.setCancelled(true);
 			}
 			return;
@@ -316,15 +321,14 @@ public class InventoryListener implements Listener {
 	@EventHandler
 	public void onInventoryClose(InventoryCloseEvent event) {
 		if (VERSION.isOrEarlier(MinecraftVersion.V1_13)) return;
-		if (event.getInventory().getHolder() instanceof BSealer) {
-			((BSealer) event.getInventory().getHolder()).closeInv();
+		if (PaperLib.getHolder(event.getInventory(), true).getHolder() instanceof BSealer holder) {
+			holder.closeInv();
 		}
 
 		if (VERSION.isOrEarlier(MinecraftVersion.V1_14)) return;
 
 		// Barrel Closing Sound
-		if (event.getInventory().getHolder() instanceof Barrel) {
-			Barrel barrel = ((Barrel) event.getInventory().getHolder());
+		if (PaperLib.getHolder(event.getInventory(), true).getHolder() instanceof Barrel barrel) {
 			barrel.playClosingSound();
 		}
 

--- a/src/main/java/com/dre/brewery/lore/BrewLore.java
+++ b/src/main/java/com/dre/brewery/lore/BrewLore.java
@@ -86,7 +86,7 @@ public class BrewLore {
 			} else if (t != null && t.isAfter(Type.SPACE)) {
 				if (hasSpace) return;
 
-				if (hasCustom || BreweryPlugin.isUseNBT()) {
+				if (hasCustom || MinecraftVersion.isUseNBT()) {
 					// We want to add the spacer if we have Custom Lore, to have a space between custom and brew lore.
 					// Also add a space if there is no Custom Lore but we don't already have a invisible data line
 					lore.add(i, Type.SPACE.id);
@@ -501,11 +501,11 @@ public class BrewLore {
 	 * Remove the Old Spacer from the legacy potion data system
 	 */
 	public void removeLegacySpacing() {
-		if (BreweryPlugin.isUseNBT()) {
+		if (MinecraftVersion.isUseNBT()) {
 			// Using NBT we don't get the invisible line, so we keep our spacing
 			return;
 		}
-		if (lore.size() > 0 && lore.get(0).equals("")) {
+		if (!lore.isEmpty() && lore.get(0).isEmpty()) {
 			lore.remove(0);
 			write();
 		}

--- a/src/main/java/com/dre/brewery/utility/Logging.java
+++ b/src/main/java/com/dre/brewery/utility/Logging.java
@@ -20,14 +20,25 @@
 
 package com.dre.brewery.utility;
 
+import com.avaje.ebean.LogLevel;
+import com.dre.brewery.BreweryPlugin;
 import com.dre.brewery.commands.subcommands.ReloadCommand;
 import com.dre.brewery.configuration.ConfigManager;
 import com.dre.brewery.configuration.files.Config;
+import io.papermc.lib.PaperLib;
+import io.papermc.lib.environments.Environment;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.Nullable;
 
 public final class Logging {
+
+    public enum LogLevel {
+        INFO,
+        WARNING,
+        ERROR,
+        DEBUG
+    }
 
     private static final Config config = ConfigManager.getConfig(Config.class);
 
@@ -102,10 +113,11 @@ public final class Logging {
     }
 
 
-    public enum LogLevel {
-        INFO,
-        WARNING,
-        ERROR,
-        DEBUG
+    public static String getEnvironmentAsString() {
+        if (MinecraftVersion.isFolia()) {
+            return "Folia";
+        }
+        return PaperLib.getEnvironment().getName();
     }
+
 }

--- a/src/main/java/com/dre/brewery/utility/MaterialUtil.java
+++ b/src/main/java/com/dre/brewery/utility/MaterialUtil.java
@@ -21,6 +21,7 @@
 package com.dre.brewery.utility;
 
 import com.dre.brewery.BreweryPlugin;
+import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -127,7 +128,7 @@ public final class MaterialUtil {
 
 	public static boolean areStairsInverted(Block block) {
 		if (VERSION.isOrEarlier(MinecraftVersion.V1_13)) {
-			MaterialData data = block.getState().getData();
+			MaterialData data = block.getState().getData(); // PaperLib not needed here
 			return data instanceof org.bukkit.material.Stairs && (((org.bukkit.material.Stairs) data).isInverted());
 		} else {
 			BlockData data = block.getBlockData();
@@ -164,7 +165,8 @@ public final class MaterialUtil {
 			}
 
 		} else {
-			Cauldron cauldron = (Cauldron) block.getState().getData();
+			// TODO: This needs to be swapped with non-deprecated API
+			Cauldron cauldron = (Cauldron) PaperLib.getBlockState(block, true).getState().getData();
 			if (cauldron.isEmpty()) {
 				return EMPTY;
 			} else if (cauldron.isFull()) {

--- a/src/main/java/com/dre/brewery/utility/MinecraftVersion.java
+++ b/src/main/java/com/dre/brewery/utility/MinecraftVersion.java
@@ -20,12 +20,14 @@
 
 package com.dre.brewery.utility;
 
+import lombok.Getter;
 import org.bukkit.Bukkit;
 
 /**
  * Enum for major Minecraft versions where Brewery needs
  * to handle things differently.
  */
+@Getter
 public enum MinecraftVersion {
 
     //V1_7("1.7"), Remove 1.7 support. We only support versions that use UUIDs.
@@ -45,14 +47,14 @@ public enum MinecraftVersion {
     V1_21("1.21"),
     UNKNOWN("Unknown");
 
+
+    private @Getter static final boolean isFolia = MinecraftVersion.checkFolia();
+    private @Getter static final boolean useNBT = NBTUtil.initNbt();
+
     private final String version;
 
     MinecraftVersion(String version) {
         this.version = version;
-    }
-
-    public String getVersion() {
-        return version;
     }
 
     public static MinecraftVersion get(String version) {
@@ -85,4 +87,12 @@ public enum MinecraftVersion {
         return this.ordinal() <= version.ordinal();
     }
 
+    private static boolean checkFolia() {
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            return true;
+        } catch (ClassNotFoundException ignored) {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
Some Paper-API specific things. Added for performance improvements since using `snapshot` on `BlockState`s and `InventoryHolder`s is way less taxing. This will probably have a noticable effect on Distillers since those call brewing stand `BlockState`s every couple of ticks. Using PaperLib for all of this so we gracefully use non-Paper methods when running on Spigot. Sucks that people actually still use Spigot nowadays.