### PR TITLE
Better Storage Mutability

### DIFF
--- a/src/main/java/com/dre/brewery/BCauldron.java
+++ b/src/main/java/com/dre/brewery/BCauldron.java
@@ -516,7 +516,7 @@ public class BCauldron {
 					} else if (isBottle) {
 						BUtil.setItemInHand(event, Material.GLASS_BOTTLE, handSwap);
 					} else {
-						BUtil.setItemInHand(event, Material.AIR, handSwap);
+						item.setAmount(0);
 					}
 				}
 			}

--- a/src/main/java/com/dre/brewery/BreweryPlugin.java
+++ b/src/main/java/com/dre/brewery/BreweryPlugin.java
@@ -121,14 +121,17 @@ public final class BreweryPlugin extends JavaPlugin {
 
 		BSealer.registerRecipe(); // Sealing table recipe
 		ConfigManager.registerDefaultPluginItems(); // Register plugin items
+
+		// Load Addons
+		addonManager = new AddonManager(this);
+		addonManager.loadAddons();
+
 		ConfigManager.loadCauldronIngredients();
 		ConfigManager.loadRecipes();
 		ConfigManager.loadDistortWords();
 		this.breweryStats = new BreweryStats(); // Load metrics
 
-        // Load Addons
-		addonManager = new AddonManager(this);
-		addonManager.loadAddons();
+
 
 
 

--- a/src/main/java/com/dre/brewery/BreweryPlugin.java
+++ b/src/main/java/com/dre/brewery/BreweryPlugin.java
@@ -174,7 +174,7 @@ public final class BreweryPlugin extends JavaPlugin {
 				.filter(Objects::nonNull)
 				.toList());
 
-
+		addonManager.enableAddons();
 		// Setup Metrics
 		this.breweryStats.setupBStats();
 		new BreweryXStats().setupBStats();

--- a/src/main/java/com/dre/brewery/api/addons/AddonManager.java
+++ b/src/main/java/com/dre/brewery/api/addons/AddonManager.java
@@ -239,6 +239,7 @@ public class AddonManager {
 							// It's important that we don't initialize any other classes before our main class.
 							clazz = Class.forName(className, false, classLoader);
 						} catch (ClassNotFoundException | NoClassDefFoundError e) {
+							Logging.errorLog("An exception occurred while trying to load a class from an addon", e);
 							continue;
 						}
 						if (BreweryAddon.class.isAssignableFrom(clazz)) {

--- a/src/main/java/com/dre/brewery/api/addons/AddonManager.java
+++ b/src/main/java/com/dre/brewery/api/addons/AddonManager.java
@@ -118,6 +118,11 @@ public class AddonManager {
 			loadAddon(file); // Go read the documentation below to understand what this does.
 		}
 
+		int loaded = LOADED_ADDONS.size();
+		if (loaded > 0) Logging.log("Loaded " + loaded + " addon(s)");
+	}
+
+	public void enableAddons() {
 		for (BreweryAddon addon : LOADED_ADDONS) {
 			try {
 				addon.onAddonEnable(); // All done, let the addon know it's been enabled.
@@ -126,8 +131,6 @@ public class AddonManager {
 				unloadAddon(addon);
 			}
 		}
-		int loaded = LOADED_ADDONS.size();
-		if (loaded > 0) Logging.log("Loaded " + loaded + " addon(s)");
 	}
 
 

--- a/src/main/java/com/dre/brewery/api/addons/BreweryAddon.java
+++ b/src/main/java/com/dre/brewery/api/addons/BreweryAddon.java
@@ -22,6 +22,7 @@ package com.dre.brewery.api.addons;
 
 import com.dre.brewery.BreweryPlugin;
 import com.dre.brewery.commands.CommandManager;
+import com.dre.brewery.storage.DataManager;
 import com.dre.brewery.utility.MinecraftVersion;
 import com.github.Anon8281.universalScheduler.scheduling.schedulers.TaskScheduler;
 import com.google.common.reflect.ClassPath;
@@ -226,6 +227,16 @@ public abstract class BreweryAddon {
 	@NotNull
 	public TaskScheduler getScheduler() {
 		return BreweryPlugin.getScheduler();
+	}
+
+	/**
+	 * Retrieves the DataManager associated with the BreweryX plugin.
+	 *
+	 * @return The DataManager instance
+	 */
+	@NotNull
+	public DataManager getDataManager() {
+		return BreweryPlugin.getDataManager();
 	}
 
 	/**

--- a/src/main/java/com/dre/brewery/commands/subcommands/ReloadAddonsCommand.java
+++ b/src/main/java/com/dre/brewery/commands/subcommands/ReloadAddonsCommand.java
@@ -36,6 +36,7 @@ public class ReloadAddonsCommand implements SubCommand {
 			AddonManager addonManager = BreweryPlugin.getAddonManager();
 			addonManager.unloadAddons();
 			addonManager.loadAddons();
+			addonManager.enableAddons();
 			Logging.msg(sender, "Finished loading " + addonManager.getAddons().size() + " addon(s)");
 			Logging.msg(sender, "&eUsing this command should be avoided as it can cause unpredictable behavior within addons!");
 		} else {

--- a/src/main/java/com/dre/brewery/commands/subcommands/ReloadCommand.java
+++ b/src/main/java/com/dre/brewery/commands/subcommands/ReloadCommand.java
@@ -26,7 +26,6 @@ import com.dre.brewery.Brew;
 import com.dre.brewery.BreweryPlugin;
 import com.dre.brewery.commands.CommandUtil;
 import com.dre.brewery.commands.SubCommand;
-import com.dre.brewery.configuration.AbstractOkaeriConfigFile;
 import com.dre.brewery.configuration.ConfigManager;
 import com.dre.brewery.configuration.configurer.TranslationManager;
 import com.dre.brewery.configuration.files.Lang;

--- a/src/main/java/com/dre/brewery/recipe/BRecipe.java
+++ b/src/main/java/com/dre/brewery/recipe/BRecipe.java
@@ -254,7 +254,7 @@ public class BRecipe implements Cloneable {
 					continue;
 				} else {
 					// TODO Maybe load later ie on first use of recipe?
-					Logging.errorLog(recipeId + ": Could not Find Plugin: " + ingredParts[1]);
+					Logging.errorLog(recipeId + ": Could not Find Plugin: " + Arrays.toString(ingredParts));
 					return null;
 				}
 			}

--- a/src/main/java/com/dre/brewery/storage/DataManager.java
+++ b/src/main/java/com/dre/brewery/storage/DataManager.java
@@ -48,7 +48,9 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Getter
@@ -58,8 +60,7 @@ public abstract class DataManager {
 
     protected static BreweryPlugin plugin = BreweryPlugin.getInstance();
     protected static long lastAutoSave = System.currentTimeMillis();
-    @Getter
-    protected static List<ExternallyAutoSavable> autoSavables = new ArrayList<>();
+    protected static Set<ExternallyAutoSavable> autoSavabales = new HashSet<>();
 
     private final DataManagerType type;
 
@@ -68,7 +69,9 @@ public abstract class DataManager {
     }
 
     public abstract boolean createTable(String name, int maxIdLength);
-    public boolean createTable(String name) { return createTable(name, 36);}
+    public boolean createTable(String name) {
+        return createTable(name, 36); // Standard UUID length is 36
+    }
     public abstract boolean dropTable(String name);
 
     public abstract <T extends SerializableThing> T getGeneric(String id, String table, Class<T> type);
@@ -173,7 +176,7 @@ public abstract class DataManager {
         saveAllPlayers(players, true);
         saveAllWakeups(wakeups, true);
 
-        for (ExternallyAutoSavable autoSaveAble : autoSavables) {
+        for (ExternallyAutoSavable autoSaveAble : autoSavabales) {
             try {
                 autoSaveAble.onAutoSave(this);
             } catch (Throwable e) {
@@ -217,6 +220,15 @@ public abstract class DataManager {
 
 
     // Utility
+
+    public static void registerAutoSavable(ExternallyAutoSavable autoSavable) {
+        autoSavabales.add(autoSavable);
+    }
+
+    public static void unregisterAutoSavable(ExternallyAutoSavable autoSavable) {
+        autoSavabales.remove(autoSavable);
+    }
+
 
     public static void loadMiscData(BreweryMiscData miscData) {
         Brew.installTime = miscData.installTime();

--- a/src/main/java/com/dre/brewery/storage/DataManager.java
+++ b/src/main/java/com/dre/brewery/storage/DataManager.java
@@ -36,18 +36,21 @@ import com.dre.brewery.storage.impls.MongoDBStorage;
 import com.dre.brewery.storage.impls.MySQLStorage;
 import com.dre.brewery.storage.impls.SQLiteStorage;
 import com.dre.brewery.storage.records.BreweryMiscData;
+import com.dre.brewery.storage.records.SerializableThing;
 import com.dre.brewery.utility.BUtil;
 import com.dre.brewery.utility.Logging;
 import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
+@Getter
 public abstract class DataManager {
 
     // TODO: Instead of using UUIDs for Barrels, Cauldrons, and Wakeups. We should figure out some hashing algorithm to generate a unique ID for each of them.
@@ -55,12 +58,20 @@ public abstract class DataManager {
     protected static BreweryPlugin plugin = BreweryPlugin.getInstance();
     protected static long lastAutoSave = System.currentTimeMillis();
 
-    @Getter
     private final DataManagerType type;
 
     protected DataManager(DataManagerType type) throws StorageInitException {
         this.type = type;
     }
+
+    public abstract boolean createTable(String name);
+    public abstract boolean dropTable(String name);
+
+    public abstract <T extends SerializableThing> T getGeneric(String id, String table, Class<T> type);
+    public abstract <T extends SerializableThing> List<T> getAllGeneric(String table, Class<T> type);
+    public abstract <T extends SerializableThing> void saveAllGeneric(List<T> serializableThings, String table, boolean overwrite, @Nullable Class<T> type);
+    public abstract <T extends SerializableThing> void saveGeneric(T serializableThing, String table);
+    public abstract void deleteGeneric(String id, String table);
 
     public abstract Barrel getBarrel(UUID id);
     public abstract Collection<Barrel> getAllBarrels();

--- a/src/main/java/com/dre/brewery/storage/impls/FlatFileStorage.java
+++ b/src/main/java/com/dre/brewery/storage/impls/FlatFileStorage.java
@@ -29,7 +29,7 @@ import com.dre.brewery.configuration.sector.capsule.ConfiguredDataManager;
 import com.dre.brewery.storage.DataManager;
 import com.dre.brewery.storage.StorageInitException;
 import com.dre.brewery.storage.records.BreweryMiscData;
-import com.dre.brewery.storage.records.SerializableThing;
+import com.dre.brewery.storage.interfaces.SerializableThing;
 import com.dre.brewery.storage.serialization.BukkitSerialization;
 import com.dre.brewery.storage.serialization.SQLDataSerializer;
 import com.dre.brewery.utility.BUtil;
@@ -88,7 +88,7 @@ public class FlatFileStorage extends DataManager {
     }
 
     @Override
-    public boolean createTable(String name) {
+    public boolean createTable(String name, int maxIdLength) {
         dataFile.createSection(name);
         save();
         return true;
@@ -130,8 +130,9 @@ public class FlatFileStorage extends DataManager {
             dataFile.set(table, null);
         }
 
-        if (section == null) {
+        if (section == null) {  // Sloppy, but whatever
             dataFile.createSection(table);
+            section = dataFile.getConfigurationSection(table);
         }
 
         for (T thing : serializableThings) {

--- a/src/main/java/com/dre/brewery/storage/impls/MongoDBStorage.java
+++ b/src/main/java/com/dre/brewery/storage/impls/MongoDBStorage.java
@@ -43,6 +43,7 @@ import com.mongodb.client.model.ReplaceOptions;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Logger;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -92,40 +93,64 @@ public class MongoDBStorage extends DataManager {
         mongoClient.close();
     }
 
+    @Override
+    public boolean createTable(String name) {
+        mongoDatabase.createCollection(collectionPrefix + name);
+        return true;
+    }
+
+    @Override
+    public boolean dropTable(String name) {
+        mongoDatabase.getCollection(collectionPrefix + name).drop();
+        return true;
+    }
+
+    @Override
+    public <T extends SerializableThing> T getGeneric(String id, String collection, Class<T> type) {
+        MongoCollection<T> mongoCollection = mongoDatabase.getCollection(collectionPrefix + collection, type);
+        return mongoCollection.find(Filters.eq(MONGO_ID, id)).first();
+    }
     private <T extends SerializableThing> T getGeneric(UUID id, String collection, Class<T> type) {
-        MongoCollection<T> mongoCollection = mongoDatabase.getCollection(collectionPrefix + collection, type);
-        return mongoCollection.find(Filters.eq(MONGO_ID, id)).first();
+        return getGeneric(id.toString(), collection, type);
     }
 
-    private <T extends SerializableThing> T getGeneric(String id, String collection, Class<T> type) {
-        MongoCollection<T> mongoCollection = mongoDatabase.getCollection(collectionPrefix + collection, type);
-        return mongoCollection.find(Filters.eq(MONGO_ID, id)).first();
-    }
-
-    private <T extends SerializableThing> List<T> getAllGeneric(String collection, Class<T> type) {
+    @Override
+    public <T extends SerializableThing> List<T> getAllGeneric(String collection, Class<T> type) {
         MongoCollection<T> mongoCollection = mongoDatabase.getCollection(collectionPrefix + collection, type);
         return mongoCollection.find().into(new ArrayList<>());
     }
 
-
-    private <T extends SerializableThing> void saveGeneric(T thing, String collection) {
+    @Override
+    public <T extends SerializableThing> void saveGeneric(T thing, String collection) {
         MongoCollection<T> mongoCollection = (MongoCollection<T>) mongoDatabase.getCollection(collectionPrefix + collection, thing.getClass());
         mongoCollection.replaceOne(Filters.eq(MONGO_ID, thing.getId()), thing, new ReplaceOptions().upsert(true));
     }
 
-    private <T extends SerializableThing> void saveAllGeneric(List<T> things, String collection, Class<T> type) {
+    @Override
+    public <T extends SerializableThing> void saveAllGeneric(List<T> things, String collection, boolean overwrite, Class<T> type) {
+        if (type == null) {
+            try {
+                throw new NullPointerException("type must not be null!");
+            } catch (NullPointerException e) {
+                Logging.errorLog("'type' was null.", e);
+                return;
+            }
+        }
         MongoCollection<T> mongoCollection = mongoDatabase.getCollection(collectionPrefix + collection, type);
 
-        Set<String> thingsIds = things.stream().map(T::getId).collect(Collectors.toSet());
-        // Delete objects from the collection that are no longer in the list
-        mongoCollection.deleteMany(Filters.not(Filters.in(MONGO_ID, thingsIds)));
+        if (overwrite) {
+            Set<String> thingsIds = things.stream().map(T::getId).collect(Collectors.toSet());
+            // Delete objects from the collection that are no longer in the list
+            mongoCollection.deleteMany(Filters.not(Filters.in(MONGO_ID, thingsIds)));
+        }
 
         for (T thing : things) {
             mongoCollection.replaceOne(Filters.eq(MONGO_ID, thing.getId()), thing, new ReplaceOptions().upsert(true)); // Upsert to handle both insert and update
         }
     }
 
-    private void deleteGeneric(UUID id, String collection) {
+    @Override
+    public void deleteGeneric(String id, String collection) {
         MongoCollection<SerializableThing> mongoCollection = mongoDatabase.getCollection(collectionPrefix + collection, SerializableThing.class);
         mongoCollection.deleteOne(Filters.eq(MONGO_ID, id));
     }
@@ -152,7 +177,7 @@ public class MongoDBStorage extends DataManager {
         List<SerializableBarrel> serializableBarrels = barrels.stream()
                 .map(SerializableBarrel::new)
                 .toList();
-        saveAllGeneric(serializableBarrels, "barrels", SerializableBarrel.class);
+        saveAllGeneric(serializableBarrels, "barrels", overwrite, SerializableBarrel.class);
     }
 
     @Override
@@ -162,7 +187,7 @@ public class MongoDBStorage extends DataManager {
 
     @Override
     public void deleteBarrel(UUID id) {
-        deleteGeneric(id, "barrels");
+        deleteGeneric(id.toString(), "barrels");
     }
 
     @Override
@@ -186,7 +211,7 @@ public class MongoDBStorage extends DataManager {
         List<SerializableCauldron> serializableCauldrons = cauldrons.stream()
                 .map(SerializableCauldron::new)
                 .toList();
-        saveAllGeneric(serializableCauldrons, "cauldrons", SerializableCauldron.class);
+        saveAllGeneric(serializableCauldrons, "cauldrons", overwrite, SerializableCauldron.class);
     }
 
     @Override
@@ -196,7 +221,7 @@ public class MongoDBStorage extends DataManager {
 
     @Override
     public void deleteCauldron(UUID id) {
-        deleteGeneric(id, "cauldrons");
+        deleteGeneric(id.toString(), "cauldrons");
     }
 
     @Override
@@ -220,7 +245,7 @@ public class MongoDBStorage extends DataManager {
         List<SerializableBPlayer> serializableBPlayers = players.stream()
                 .map(SerializableBPlayer::new)
                 .toList();
-        saveAllGeneric(serializableBPlayers, "players", SerializableBPlayer.class);
+        saveAllGeneric(serializableBPlayers, "players", overwrite, SerializableBPlayer.class);
     }
 
     @Override
@@ -230,7 +255,7 @@ public class MongoDBStorage extends DataManager {
 
     @Override
     public void deletePlayer(UUID playerUUID) {
-        deleteGeneric(playerUUID, "players");
+        deleteGeneric(playerUUID.toString(), "players");
     }
 
     @Override
@@ -254,7 +279,7 @@ public class MongoDBStorage extends DataManager {
         List<SerializableWakeup> serializableWakeups = wakeups.stream()
                 .map(SerializableWakeup::new)
                 .toList();
-        saveAllGeneric(serializableWakeups, "wakeups", SerializableWakeup.class);
+        saveAllGeneric(serializableWakeups, "wakeups", overwrite, SerializableWakeup.class);
     }
 
     @Override
@@ -264,7 +289,7 @@ public class MongoDBStorage extends DataManager {
 
     @Override
     public void deleteWakeup(UUID id) {
-        deleteGeneric(id, "wakeups");
+        deleteGeneric(id.toString(), "wakeups");
     }
 
     @Override

--- a/src/main/java/com/dre/brewery/storage/impls/MongoDBStorage.java
+++ b/src/main/java/com/dre/brewery/storage/impls/MongoDBStorage.java
@@ -31,7 +31,7 @@ import com.dre.brewery.storage.records.BreweryMiscData;
 import com.dre.brewery.storage.records.SerializableBPlayer;
 import com.dre.brewery.storage.records.SerializableBarrel;
 import com.dre.brewery.storage.records.SerializableCauldron;
-import com.dre.brewery.storage.records.SerializableThing;
+import com.dre.brewery.storage.interfaces.SerializableThing;
 import com.dre.brewery.storage.records.SerializableWakeup;
 import com.dre.brewery.utility.Logging;
 import com.mongodb.client.MongoClient;
@@ -43,7 +43,6 @@ import com.mongodb.client.model.ReplaceOptions;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Logger;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -94,7 +93,7 @@ public class MongoDBStorage extends DataManager {
     }
 
     @Override
-    public boolean createTable(String name) {
+    public boolean createTable(String name, int maxIdLength) {
         mongoDatabase.createCollection(collectionPrefix + name);
         return true;
     }
@@ -128,14 +127,7 @@ public class MongoDBStorage extends DataManager {
 
     @Override
     public <T extends SerializableThing> void saveAllGeneric(List<T> things, String collection, boolean overwrite, Class<T> type) {
-        if (type == null) {
-            try {
-                throw new NullPointerException("type must not be null!");
-            } catch (NullPointerException e) {
-                Logging.errorLog("'type' was null.", e);
-                return;
-            }
-        }
+        assert type != null : "'type' cannot be null!";
         MongoCollection<T> mongoCollection = mongoDatabase.getCollection(collectionPrefix + collection, type);
 
         if (overwrite) {

--- a/src/main/java/com/dre/brewery/storage/impls/MySQLStorage.java
+++ b/src/main/java/com/dre/brewery/storage/impls/MySQLStorage.java
@@ -31,7 +31,7 @@ import com.dre.brewery.storage.records.BreweryMiscData;
 import com.dre.brewery.storage.records.SerializableBPlayer;
 import com.dre.brewery.storage.records.SerializableBarrel;
 import com.dre.brewery.storage.records.SerializableCauldron;
-import com.dre.brewery.storage.records.SerializableThing;
+import com.dre.brewery.storage.interfaces.SerializableThing;
 import com.dre.brewery.storage.records.SerializableWakeup;
 import com.dre.brewery.storage.serialization.SQLDataSerializer;
 import com.dre.brewery.utility.Logging;
@@ -100,8 +100,8 @@ public class MySQLStorage extends DataManager {
 
 
     @Override
-    public boolean createTable(String name) {
-        String sql = "CREATE TABLE IF NOT EXISTS " + tablePrefix + name + " (id VARCHAR(36) PRIMARY KEY, data LONGTEXT);";
+    public boolean createTable(String name, int maxIdLength) {
+        String sql = "CREATE TABLE IF NOT EXISTS " + tablePrefix + name + " (id VARCHAR(" + maxIdLength + ") PRIMARY KEY, data LONGTEXT);";
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.execute();
             return true;

--- a/src/main/java/com/dre/brewery/storage/impls/MySQLStorage.java
+++ b/src/main/java/com/dre/brewery/storage/impls/MySQLStorage.java
@@ -35,6 +35,7 @@ import com.dre.brewery.storage.records.SerializableThing;
 import com.dre.brewery.storage.records.SerializableWakeup;
 import com.dre.brewery.storage.serialization.SQLDataSerializer;
 import com.dre.brewery.utility.Logging;
+import org.jetbrains.annotations.Nullable;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -97,7 +98,33 @@ public class MySQLStorage extends DataManager {
         }
     }
 
-    private <T> T getGeneric(UUID id, String table, Class<T> type) {
+
+    @Override
+    public boolean createTable(String name) {
+        String sql = "CREATE TABLE IF NOT EXISTS " + tablePrefix + name + " (id VARCHAR(36) PRIMARY KEY, data LONGTEXT);";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.execute();
+            return true;
+        } catch (SQLException e) {
+            Logging.errorLog("Failed to create table: " + name + " due to MySQL exception!", e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean dropTable(String name) {
+        String sql = "DROP TABLE IF EXISTS " + tablePrefix + name;
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.execute();
+            return true;
+        } catch (SQLException e) {
+            Logging.errorLog("Failed to drop table: " + name + " due to MySQL exception!", e);
+            return false;
+        }
+    }
+
+    @Override
+    public <T extends SerializableThing> T getGeneric(String id, String table, Class<T> type) {
         String sql = "SELECT data FROM " + tablePrefix + table + " WHERE id = ?";
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, id.toString());
@@ -112,7 +139,8 @@ public class MySQLStorage extends DataManager {
         return null;
     }
 
-    private <T extends SerializableThing> List<T> getAllGeneric(String table, Class<T> type) {
+    @Override
+    public <T extends SerializableThing> List<T> getAllGeneric(String table, Class<T> type) {
         String sql = "SELECT id, data FROM " + tablePrefix + table;
         List<T> objects = new ArrayList<>();
 
@@ -130,7 +158,8 @@ public class MySQLStorage extends DataManager {
     }
 
 
-	private void saveAllGeneric(List<? extends SerializableThing> serializableThings, String table, boolean overwrite) {
+    @Override
+	public <T extends SerializableThing> void saveAllGeneric(List<T> serializableThings, String table, boolean overwrite, @Nullable Class<T> type) {
 		if (!overwrite) {
 			String insertSql = "INSERT INTO " + tablePrefix + table + " (id, data) VALUES (?, ?) ON DUPLICATE KEY UPDATE data = VALUES(data)";
 			try (PreparedStatement insertStatement = connection.prepareStatement(insertSql)) {
@@ -184,8 +213,12 @@ public class MySQLStorage extends DataManager {
 			Logging.errorLog("Failed to manage transaction for saving objects to: " + table + " due to MySQL exception!", e);
 		}
 	}
+    private <T extends SerializableThing> void saveAllGeneric(List<T> serializableThings, String table, boolean overwrite) {
+        saveAllGeneric(serializableThings, table, overwrite, null);
+    }
 
-    private <T extends SerializableThing> void saveGeneric(T serializableThing, String table) {
+    @Override
+    public <T extends SerializableThing> void saveGeneric(T serializableThing, String table) {
         String sql = "INSERT INTO " + tablePrefix + table + " (id, data) VALUES (?, ?) ON DUPLICATE KEY UPDATE data = VALUES(data)";
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, serializableThing.getId());
@@ -196,10 +229,11 @@ public class MySQLStorage extends DataManager {
         }
     }
 
-    private void deleteGeneric(UUID id, String table) {
+    @Override
+    public void deleteGeneric(String id, String table) {
         String sql = "DELETE FROM " + tablePrefix + table + " WHERE id = ?";
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
-            statement.setString(1, id.toString());
+            statement.setString(1, id);
             statement.execute();
         } catch (SQLException e) {
             Logging.errorLog("Failed to delete object from: " + table + ", from: MySQL!", e);
@@ -208,7 +242,7 @@ public class MySQLStorage extends DataManager {
 
     @Override
     public Barrel getBarrel(UUID id) {
-        SerializableBarrel serializableBarrel = getGeneric(id, "barrels", SerializableBarrel.class);
+        SerializableBarrel serializableBarrel = getGeneric(id.toString(), "barrels", SerializableBarrel.class);
         if (serializableBarrel != null) {
             return serializableBarrel.toBarrel();
         }
@@ -237,12 +271,12 @@ public class MySQLStorage extends DataManager {
 
     @Override
     public void deleteBarrel(UUID id) {
-        deleteGeneric(id, "barrels");
+        deleteGeneric(id.toString(), "barrels");
     }
 
     @Override
     public BCauldron getCauldron(UUID id) {
-        SerializableCauldron serializableCauldron = getGeneric(id, "cauldrons", SerializableCauldron.class);
+        SerializableCauldron serializableCauldron = getGeneric(id.toString(), "cauldrons", SerializableCauldron.class);
         if (serializableCauldron != null) {
             return serializableCauldron.toCauldron();
         }
@@ -271,12 +305,12 @@ public class MySQLStorage extends DataManager {
 
     @Override
     public void deleteCauldron(UUID id) {
-        deleteGeneric(id, "cauldrons");
+        deleteGeneric(id.toString(), "cauldrons");
     }
 
     @Override
     public BPlayer getPlayer(UUID playerUUID) {
-        SerializableBPlayer serializableBPlayer = getGeneric(playerUUID, "players", SerializableBPlayer.class);
+        SerializableBPlayer serializableBPlayer = getGeneric(playerUUID.toString(), "players", SerializableBPlayer.class);
         if (serializableBPlayer != null) {
             return serializableBPlayer.toBPlayer();
         }
@@ -305,12 +339,12 @@ public class MySQLStorage extends DataManager {
 
     @Override
     public void deletePlayer(UUID playerUUID) {
-        deleteGeneric(playerUUID, "players");
+        deleteGeneric(playerUUID.toString(), "players");
     }
 
     @Override
     public Wakeup getWakeup(UUID id) {
-        SerializableWakeup serializableWakeup = getGeneric(id, "wakeups", SerializableWakeup.class);
+        SerializableWakeup serializableWakeup = getGeneric(id.toString(), "wakeups", SerializableWakeup.class);
         if (serializableWakeup != null) {
             return serializableWakeup.toWakeup();
         }
@@ -339,7 +373,7 @@ public class MySQLStorage extends DataManager {
 
     @Override
     public void deleteWakeup(UUID id) {
-        deleteGeneric(id, "wakeups");
+        deleteGeneric(id.toString(), "wakeups");
     }
 
     @Override

--- a/src/main/java/com/dre/brewery/storage/impls/SQLiteStorage.java
+++ b/src/main/java/com/dre/brewery/storage/impls/SQLiteStorage.java
@@ -31,7 +31,7 @@ import com.dre.brewery.storage.records.BreweryMiscData;
 import com.dre.brewery.storage.records.SerializableBPlayer;
 import com.dre.brewery.storage.records.SerializableBarrel;
 import com.dre.brewery.storage.records.SerializableCauldron;
-import com.dre.brewery.storage.records.SerializableThing;
+import com.dre.brewery.storage.interfaces.SerializableThing;
 import com.dre.brewery.storage.records.SerializableWakeup;
 import com.dre.brewery.storage.serialization.SQLDataSerializer;
 import com.dre.brewery.utility.Logging;
@@ -102,8 +102,8 @@ public class SQLiteStorage extends DataManager {
     }
 
     @Override
-    public boolean createTable(String name) {
-        String sql = "CREATE TABLE IF NOT EXISTS " + tablePrefix + name + " (id VARCHAR(36) PRIMARY KEY, data LONGTEXT);";
+    public boolean createTable(String name, int maxIdLength) {
+        String sql = "CREATE TABLE IF NOT EXISTS " + tablePrefix + name + " (id VARCHAR(" + maxIdLength + ") PRIMARY KEY, data LONGTEXT);";
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.execute();
             return true;

--- a/src/main/java/com/dre/brewery/storage/interfaces/ExternallyAutoSavable.java
+++ b/src/main/java/com/dre/brewery/storage/interfaces/ExternallyAutoSavable.java
@@ -22,6 +22,21 @@ package com.dre.brewery.storage.interfaces;
 
 import com.dre.brewery.storage.DataManager;
 
+/**
+ * Allows an external class (a class outside or inside) of this Plugin to be auto-saved by Brewery.
+ * Auto saving will occur every X number of minutes and will also occur when this Plugin is disabled.
+ * <p>
+ * A class
+ * implementing this interface must be registered with BreweryX auto-savable system. {@link DataManager#registerAutoSavable(ExternallyAutoSavable)}
+ *
+ * @see DataManager#registerAutoSavable(ExternallyAutoSavable)
+ * @see DataManager#unregisterAutoSavable(ExternallyAutoSavable) 
+ */
 public interface ExternallyAutoSavable {
+
+    /**
+     * Fired when Brewery is handling its auto-save task.
+     * @param dataManager Instance of the DataManager
+     */
     void onAutoSave(DataManager dataManager);
 }

--- a/src/main/java/com/dre/brewery/storage/interfaces/ExternallyAutoSavable.java
+++ b/src/main/java/com/dre/brewery/storage/interfaces/ExternallyAutoSavable.java
@@ -18,8 +18,10 @@
  * along with BreweryX. If not, see <http://www.gnu.org/licenses/gpl-3.0.html>.
  */
 
-package com.dre.brewery.storage.records;
+package com.dre.brewery.storage.interfaces;
 
-public interface SerializableThing {
-    String getId();
+import com.dre.brewery.storage.DataManager;
+
+public interface ExternallyAutoSavable {
+    void onAutoSave(DataManager dataManager);
 }

--- a/src/main/java/com/dre/brewery/storage/interfaces/SerializableThing.java
+++ b/src/main/java/com/dre/brewery/storage/interfaces/SerializableThing.java
@@ -20,6 +20,16 @@
 
 package com.dre.brewery.storage.interfaces;
 
+/**
+ * Represents an object that can be serialized and uniquely identified.
+ * Implementations of this interface should serialize their respective data into
+ * a format that enables persistent storage and retrieval.
+ */
 public interface SerializableThing {
+
+    /**
+     * The identifier of this serializable object. Usually a UUID or similar.
+     * @return The identifier as a String
+     */
     String getId();
 }

--- a/src/main/java/com/dre/brewery/storage/interfaces/SerializableThing.java
+++ b/src/main/java/com/dre/brewery/storage/interfaces/SerializableThing.java
@@ -18,22 +18,8 @@
  * along with BreweryX. If not, see <http://www.gnu.org/licenses/gpl-3.0.html>.
  */
 
-package com.dre.brewery.storage.records;
+package com.dre.brewery.storage.interfaces;
 
-import com.dre.brewery.storage.interfaces.SerializableThing;
-
-import java.util.List;
-
-/**
- * Miscellaneous save data about brewery.
- * These were added by the original author(s) and their source/usage hasn't been completely
- * read through by me.
- */
-public record BreweryMiscData(long installTime, long mcBarrelTime, List<Long> prevSaveSeeds, List<Integer> brewsCreated,
-                              int brewsCreatedHash) implements SerializableThing {
-
-    @Override
-    public String getId() {
-        return "misc";
-    }
+public interface SerializableThing {
+    String getId();
 }

--- a/src/main/java/com/dre/brewery/storage/records/SerializableBPlayer.java
+++ b/src/main/java/com/dre/brewery/storage/records/SerializableBPlayer.java
@@ -21,6 +21,7 @@
 package com.dre.brewery.storage.records;
 
 import com.dre.brewery.BPlayer;
+import com.dre.brewery.storage.interfaces.SerializableThing;
 
 /**
  * Represents a player that can be serialized.

--- a/src/main/java/com/dre/brewery/storage/records/SerializableBarrel.java
+++ b/src/main/java/com/dre/brewery/storage/records/SerializableBarrel.java
@@ -22,6 +22,7 @@ package com.dre.brewery.storage.records;
 
 import com.dre.brewery.Barrel;
 import com.dre.brewery.storage.DataManager;
+import com.dre.brewery.storage.interfaces.SerializableThing;
 import com.dre.brewery.storage.serialization.BukkitSerialization;
 import com.dre.brewery.utility.BUtil;
 import com.dre.brewery.utility.BoundingBox;

--- a/src/main/java/com/dre/brewery/storage/records/SerializableCauldron.java
+++ b/src/main/java/com/dre/brewery/storage/records/SerializableCauldron.java
@@ -23,6 +23,7 @@ package com.dre.brewery.storage.records;
 import com.dre.brewery.BCauldron;
 import com.dre.brewery.BIngredients;
 import com.dre.brewery.storage.DataManager;
+import com.dre.brewery.storage.interfaces.SerializableThing;
 import com.dre.brewery.utility.BUtil;
 import org.bukkit.Location;
 

--- a/src/main/java/com/dre/brewery/storage/records/SerializableWakeup.java
+++ b/src/main/java/com/dre/brewery/storage/records/SerializableWakeup.java
@@ -22,6 +22,7 @@ package com.dre.brewery.storage.records;
 
 import com.dre.brewery.Wakeup;
 import com.dre.brewery.storage.DataManager;
+import com.dre.brewery.storage.interfaces.SerializableThing;
 import com.dre.brewery.utility.BUtil;
 import org.bukkit.Location;
 

--- a/src/main/java/com/dre/brewery/storage/serialization/SQLDataSerializer.java
+++ b/src/main/java/com/dre/brewery/storage/serialization/SQLDataSerializer.java
@@ -22,6 +22,7 @@ package com.dre.brewery.storage.serialization;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import lombok.Getter;
 
 import java.lang.reflect.Modifier;
 import java.util.Base64;
@@ -29,6 +30,7 @@ import java.util.Base64;
 /**
  * Serializes the given object to JSON and then to a Base64 encoded string.
  */
+@Getter
 public class SQLDataSerializer {
     private final Gson gson = new GsonBuilder().setPrettyPrinting().excludeFieldsWithModifiers(Modifier.STATIC).create();
 


### PR DESCRIPTION
Opens up the storage aspect of BX for adding any type of `SerializableThing`. Also adds `ExternallyAutoSavable` which allows external classes to be auto-saved by BX. This is *mainly* for the Addon API. Addons, on occasion, may need to store persistent data depending on what they're doing and I don't want addons to be using a bunch of FlatFiles for storage and I also want addons to be able to store persistent data across any Storage type of BX. This PR cleans up some of the DataManager implementations too.