### PR TITLE
Add an indicator that a brew is alcoholic

### DIFF
--- a/src/main/java/com/dre/brewery/configuration/files/Config.java
+++ b/src/main/java/com/dre/brewery/configuration/files/Config.java
@@ -140,6 +140,9 @@ public class Config extends AbstractOkaeriConfigFile {
 	@LocalizedComment("config.alwaysShowAlc")
 	private boolean alwaysShowAlc = false;
 
+	@LocalizedComment("config.alwaysShowAlcIndicator")
+	private boolean alwaysShowAlcIndicator = true;
+
 	@LocalizedComment("config.showBrewer")
 	private boolean showBrewer = false;
 

--- a/src/main/java/com/dre/brewery/configuration/files/Lang.java
+++ b/src/main/java/com/dre/brewery/configuration/files/Lang.java
@@ -187,6 +187,8 @@ public class Lang extends AbstractOkaeriConfigFile {
     private String brewMinute;
     @CustomKey("Brew_Alc")
     private String brewAlc;
+	@CustomKey("Brew_Alcoholic")
+	private String brewAlcoholic;
     @CustomKey("Brew_Brewer")
     private String brewBrewer;
 

--- a/src/main/java/com/dre/brewery/lore/BrewLore.java
+++ b/src/main/java/com/dre/brewery/lore/BrewLore.java
@@ -294,9 +294,11 @@ public class BrewLore {
 	}
 
 	public void updateAlc(boolean inDistiller) {
-		if (!brew.isUnlabeled() && (inDistiller || config.isAlwaysShowAlc()) && (!brew.hasRecipe() || brew.getCurrentRecipe().getAlcohol() != 0)) {
-			int alc = brew.getOrCalcAlc();
+		int alc = brew.getOrCalcAlc();
+		if (!brew.isUnlabeled() && (inDistiller || config.isAlwaysShowAlc()) && alc != 0) {
 			addOrReplaceLore(Type.ALC, "§8", lang.getEntry("Brew_Alc", alc + ""));
+		} else if (config.isAlwaysShowAlcIndicator() && alc > 0) {
+			addOrReplaceLore(Type.ALC, "§8", lang.getEntry("Brew_Alcoholic"));
 		} else {
 			removeLore(Type.ALC);
 		}

--- a/src/main/resources/config-langs/en.yml
+++ b/src/main/resources/config-langs/en.yml
@@ -50,7 +50,12 @@ config:
     By default, Brewery uses Smoker as a Sealing Table, this option allows you to change it
     IMPORTANT: It needs to be a container - meaning a block that can store items (e.g., SMOKER, CHEST, BLAST_FURNACE).
   alwaysShowQuality: "Always show the 1-5 stars on the item depending on the quality. If false, they will only appear when brewing [true]"
-  alwaysShowAlc: "Always show the alcohol content on the item. If false, it will only show in the brewing stand [false]"
+  alwaysShowAlc: |
+    Always show the alcohol content on the item. If false, it will only show in the brewing stand [false]
+    Sealed brews will not show the alcohol content regardless of this setting
+  alwaysShowAlcIndicator: |
+    Always show that a brew is alcoholic by putting "Alcoholic" in the item's lore
+    Sealed brews will show that a brew is alcoholic, but not its alcohol content
   showBrewer: "If we should show who brewed the drink [false]"
   requireKeywordOnSigns: "If barrels are only created when the sign placed contains the word \"barrel\" (or a translation when using another language) [true]"
   ageInMCBarrels: "If aging in -Minecraft- Barrels in enabled [true] and how many Brewery drinks can be put into them [6]"
@@ -61,14 +66,14 @@ config:
     The used Ingredients and other brewing-data is saved to all Brewery Items. To prevent
     hacked clients from reading what exactly was used to brew an item, the data can be encoded/scrambled.
     This is a fast process to stop players from hacking out recipes, once they get hold of a brew.
-    
+
     Only drawback: brew items can only be used on another server with the same encodeKey.
     When using Brews on multiple (BungeeCord) Servers, define a MYSQL database in the 'storage' settings.
-    
+
     So enable this if you want to make recipe cheating harder, but don't share any brews by world download, schematics, or other means. [false]
   useOtherPlugins: |
     -- Plugin Compatibility --
-    
+
     Enable checking of other Plugins (if installed) for Barrel Permissions [true]
     Plugins 'Landlord' and 'Protection Stones' use the WorldGuard Flag. 'ClaimChunk' is natively supported.
   useVirtualChestPerms: |
@@ -97,8 +102,8 @@ config:
   words: |
     Words and letters that will be altered when chatting while being drunk.
     Will be processed from first to last and a written sentence is altered in that order.
-        
-    replace: Word or letter to be replaced. (Special: "-space": replaces space, "-random": insert into random position, "-all": everything, "-start": At Beginning, "-end": At the End.)  
+
+    replace: Word or letter to be replaced. (Special: "-space": replaces space, "-random": insert into random position, "-all": everything, "-start": At Beginning, "-end": At the End.)
     to: What to replace it with.
     pre: Words and Letters before the wanted word (split with ",")
     match: true = one of the "pre"-Words has to be before the wanted Word, false = none of the "pre" Words is allowed before the wanted Word
@@ -115,45 +120,45 @@ config:
 recipesFile:
   header: |
     -- Recipes for Potions --
-         
+
     Proper guide for this section can be found in our wiki here - https://brewery.lumamc.net/guide/recipies/
-    
+
     enabled: true if the recipe should be enabled, false if it should be disabled
-         
+
     name: Different names for bad/normal/good (Formatting codes possible: such as &6 or hex as &#123123)
       name: "Worst drink/Good Drink/Best drink i had in my entire life!"
-           
+
     ingredients: List of 'material/amount'
       With an item in your hand, use /brew ItemName to get its material for use in a recipe
       A list of materials can be found here: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html
       Plugin items with 'plugin:id' (Currently supporting Brewery, Oraxen, ItemsAdder)
       Or a custom item defined above
-         
+
     cookingtime: Time in real minutes ingredients have to boil
-        
+
     distillruns: How often it has to be distilled for full alcohol (0=without distilling)
-        
+
     distilltime: How long (in seconds) one distill-run takes (0=Default time of 40 sec) MC Default would be 20 sec
-        
+
     wood: Wood of the barrel 0=any 1=Birch 2=Oak 3=Jungle 4=Spruce 5=Acacia 6=Dark Oak 7=Crimson 8=Warped 9=Mangrove 10=Cherry 11=Bamboo (12=Cut Copper)
       The Minecraft barrel is made of oak
-        
+
     age: Time in Minecraft-days, the potion has to age in a barrel 0=no aging
-        
+
     color: Color of the potion after distilling/aging.
       Usable Colors: DARK_RED, RED, BRIGHT_RED, ORANGE, YELLOW, PINK, PURPLE, BLUE, CYAN, WATER, TEAL, OLIVE, GREEN, LIME, BLACK, GREY, BRIGHT_GREY, WHITE
       Or RGB colors (hex: for example '99FF33') (with '') (search for "HTML color" on the internet)
-        
+
     difficulty: 1-10 accuracy needed to get good quality (1 = unaccurate/easy, 10 = very precise/hard)
-        
+
     alcohol: Absolute amount of alcohol 0-100 in a perfect potion (will be added directly to the player, where 100 means fainting)
-        
+
     lore: List of additional text on the finished brew. (Formatting codes possible: such as &6)
       Specific lore for quality possible, using + bad, ++ normal, +++ good, added to the front of the line.
       - +++ This is the best drink!
       - ++ This is decent drink.
       - + This is the worst drink
-        
+
     servercommands: List of Commands executed by the -Server- when drinking the brew (Can use %player_name%  %quality%)
       Specific Commands for quality possible, using + bad, ++ normal, +++ good, added to the front of the line.
       - +++ op %player%
@@ -161,7 +166,7 @@ recipesFile:
       - + kill %player%
       Command execution can be delayed by adding "/ <amount>s" to the end, like this:
       - op Jsinco / 3s
-        
+
     playercommands: List of Commands executed by the -Player- when drinking the brew (Can use %player_name%  %quality%)
       Specific Commands for quality possible, using + bad, ++ normal, +++ good, added to the front of the line.
       - +++ spawn
@@ -169,18 +174,18 @@ recipesFile:
       - + suicide
       Command execution can be delayed by adding "/ <amount>s" to the end, like this:
       - op Jsinco / 3s
-        
+
     drinkmessage: Chat-message to the Player when drinking the Brew
-        
+
     drinktitle: Title on Screen to the Player when drinking the Brew
-        
+
     glint: Boolean if the item should have a glint (enchant glint)
-        
+
     customModelData: Custom Model Data Tag. This is a number that can be used to add custom textures to the item.
       Can specify one for all, or one for each quality, separated by /
       customModelData: 1
       customModelData: 1/2/3
-        
+
     effects: List of effect/level/duration  Special potion-effect when drinking, duration in seconds.
       Possible Effects: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/potion/PotionEffectType.html
       Level or Duration ranges may be specified with a "-", ex. 'SPEED/1-2/30-40' = lvl 1 and 30 sec at worst and lvl 2 and 40 sec at best
@@ -197,26 +202,26 @@ cauldronFile:
     -- Ingredients in the Cauldron --
     Which Ingredients are accepted by the Cauldron and the base potion resulting from them
     You only need to add something here if you want to specify a custom name or color for the base potion
-    
+
     name: Name of the base potion coming out of the Cauldron (Formatting codes possible: such as &6)
-    
+
     ingredients: List of 'material/amount'
       With an item in your hand, use /brew ItemName to get its material for use in a recipe
       (Item-ids instead of material are not supported by bukkit anymore and will not work)
       A list of materials can be found here: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html
-    
+
     color: Color of the base potion from a cauldron. Defaults to CYAN
       Usable Colors: DARK_RED, RED, BRIGHT_RED, ORANGE, YELLOW, PINK, PURPLE, BLUE, CYAN, WATER, TEAL, OLIVE, GREEN, LIME, BLACK, GREY, BRIGHT_GREY, WHITE
       Or RGB colors (hex: for example '99FF33') (with '') (search for "HTML color" on the internet)
-    
+
     cookParticles:
       Color of the Particles above the cauldron at different cooking-times
       Color and minute during which each color should appear, i.e. one color at 8 minutes fading to another at 18 minutes.
       As List, each Color as name or RGB, see above. Written as 'Color/Minute'
       It will fade to the last color in the end, if there is only one color in the list, it will fade to grey
-    
+
     lore: List of additional text on the base potion. (Formatting codes possible: such as &6 or hex as #&<hex>)
-    
+
     customModelData: Custom Model Data Tag. This is a number that can be used to add custom textures to the item.
 
 
@@ -224,9 +229,9 @@ customItemsFile:
   header: |
     -- Define custom items --
     The defined id can then be used in recipes
-            
-    matchAny: true if it is already enough if one of the info matches     
-    material: Which type the item has to be 
-    name: Which name the item has to be (Formatting codes possible: such as &6 or hex as &#<hex>)  
-    lore: What has to be in the lore of the item   
+
+    matchAny: true if it is already enough if one of the info matches
+    material: Which type the item has to be
+    name: Which name the item has to be (Formatting codes possible: such as &6 or hex as &#<hex>)
+    lore: What has to be in the lore of the item
     customModelData: Custom Model Data Int. Whatever Model data number the item has to have in a list format

--- a/src/main/resources/languages/en.yml
+++ b/src/main/resources/languages/en.yml
@@ -18,6 +18,7 @@ Brew_Years: Years
 Brew_fermented: fermented
 Brew_minute: minute
 Brew_Alc: Alc &v1ml
+Brew_Alcoholic: Alcoholic
 Brew_Brewer: 'Brewer: &v1'
 
 # CMD


### PR DESCRIPTION
Adds a config value to always show that a brew is alcoholic by adding "Alcoholic" to its lore, without revealing the alcohol content. This is so players can tell that a brew is alcoholic before drinking, even if sealed and renamed.