### PR TITLE
BUtil cleanup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ plugins {
 }
 
 group = "com.dre.brewery"
-version = "3.4.7"
+version = "3.4.8-SNAPSHOT"
 val langVersion: Int = 17
 val encoding: String = "UTF-8"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ plugins {
 }
 
 group = "com.dre.brewery"
-version = "3.4.8-SNAPSHOT"
+version = "3.4.7"
 val langVersion: Int = 17
 val encoding: String = "UTF-8"
 

--- a/src/main/java/com/dre/brewery/Barrel.java
+++ b/src/main/java/com/dre/brewery/Barrel.java
@@ -30,7 +30,6 @@ import com.dre.brewery.configuration.files.Lang;
 import com.dre.brewery.integration.Hook;
 import com.dre.brewery.integration.barrel.LogBlockBarrel;
 import com.dre.brewery.lore.BrewLore;
-import com.dre.brewery.utility.BUtil;
 import com.dre.brewery.utility.BoundingBox;
 import com.dre.brewery.utility.Logging;
 import com.dre.brewery.utility.MinecraftVersion;
@@ -98,7 +97,7 @@ public class Barrel extends BarrelBody implements InventoryHolder {
         if (items != null) {
             for (String slot : items.keySet()) {
                 if (items.get(slot) instanceof ItemStack) {
-                    this.inventory.setItem(BUtil.parseInt(slot), (ItemStack) items.get(slot));
+                    this.inventory.setItem(Integer.parseInt(slot), (ItemStack) items.get(slot));
                 }
             }
         }

--- a/src/main/java/com/dre/brewery/commands/CommandUtil.java
+++ b/src/main/java/com/dre/brewery/commands/CommandUtil.java
@@ -73,7 +73,7 @@ public class CommandUtil {
 
         int page = 1;
         if (args.length > 1) {
-            page = BUtil.parseInt(args[1]);
+            page = BUtil.parseIntOrZero(args[1]);
         }
 
         ArrayList<String> commands = getCommands(sender);
@@ -96,12 +96,12 @@ public class CommandUtil {
         boolean hasQuality = false;
         String pName = null;
         if (args.length > 2) {
-            quality = BUtil.parseInt(args[args.length - 1]);
+            quality = BUtil.getRandomIntInRange(args[args.length - 1]);
 
             if (quality <= 0 || quality > 10) {
                 pName = args[args.length - 1];
                 if (args.length > 3) {
-                    quality = BUtil.parseInt(args[args.length - 2]);
+                    quality = BUtil.getRandomIntInRange(args[args.length - 2]);
                 }
             }
             if (quality > 0 && quality <= 10) {

--- a/src/main/java/com/dre/brewery/commands/subcommands/CopyCommand.java
+++ b/src/main/java/com/dre/brewery/commands/subcommands/CopyCommand.java
@@ -36,7 +36,7 @@ public class CopyCommand implements SubCommand {
     @Override
     public void execute(BreweryPlugin breweryPlugin, Lang lang, CommandSender sender, String label, String[] args) {
         if (args.length > 1) {
-            cmdCopy(sender, BUtil.parseInt(args[1]), lang);
+            cmdCopy(sender, BUtil.getRandomIntInRange(args[1]), lang);
         } else {
             cmdCopy(sender, 1, lang);
         }

--- a/src/main/java/com/dre/brewery/commands/subcommands/HelpCommand.java
+++ b/src/main/java/com/dre/brewery/commands/subcommands/HelpCommand.java
@@ -37,7 +37,7 @@ public class HelpCommand implements SubCommand {
     public void execute(BreweryPlugin breweryPlugin, Lang lang, CommandSender sender, String label, String[] args) {
         int page = 1;
         if (args.length > 1) {
-            page = BUtil.parseInt(args[1]);
+            page = BUtil.parseIntOrZero(args[1]);
         }
 
         ArrayList<String> commands = CommandUtil.getCommands(sender);

--- a/src/main/java/com/dre/brewery/commands/subcommands/PukeCommand.java
+++ b/src/main/java/com/dre/brewery/commands/subcommands/PukeCommand.java
@@ -56,7 +56,7 @@ public class PukeCommand implements SubCommand {
         }
         int count = 0;
         if (args.length > 2) {
-            count = BUtil.parseInt(args[2]);
+            count = BUtil.getRandomIntInRange(args[2]);
         }
         if (count <= 0) {
             count = 20 + (int) (Math.random() * 40);

--- a/src/main/java/com/dre/brewery/commands/subcommands/WakeupCommand.java
+++ b/src/main/java/com/dre/brewery/commands/subcommands/WakeupCommand.java
@@ -47,7 +47,7 @@ public class WakeupCommand implements SubCommand {
             int page = 1;
             String world = null;
             if (args.length > 2) {
-                page = BUtil.parseInt(args[2]);
+                page = BUtil.parseIntOrZero(args[2]);
             }
             if (args.length > 3) {
                 world = args[3];
@@ -57,7 +57,7 @@ public class WakeupCommand implements SubCommand {
         } else if (args[1].equalsIgnoreCase("remove")) {
 
             if (args.length > 2) {
-                int id = BUtil.parseInt(args[2]);
+                int id = BUtil.parseIntOrZero(args[2]);
                 Wakeup.remove(sender, id);
             } else {
                 lang.sendEntry(sender, "Etc_Usage");
@@ -68,7 +68,7 @@ public class WakeupCommand implements SubCommand {
 
             int id = -1;
             if (args.length > 2) {
-                id = BUtil.parseInt(args[2]);
+                id = BUtil.parseIntOrZero(args[2]);
                 if (id < 0) {
                     id = 0;
                 }

--- a/src/main/java/com/dre/brewery/configuration/sector/capsule/ConfigCauldronIngredient.java
+++ b/src/main/java/com/dre/brewery/configuration/sector/capsule/ConfigCauldronIngredient.java
@@ -21,11 +21,7 @@
 package com.dre.brewery.configuration.sector.capsule;
 
 import eu.okaeri.configs.OkaeriConfig;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.List;
 

--- a/src/main/java/com/dre/brewery/listeners/BlockListener.java
+++ b/src/main/java/com/dre/brewery/listeners/BlockListener.java
@@ -20,11 +20,7 @@
 
 package com.dre.brewery.listeners;
 
-import com.dre.brewery.BPlayer;
-import com.dre.brewery.BSealer;
-import com.dre.brewery.Barrel;
-import com.dre.brewery.BreweryPlugin;
-import com.dre.brewery.DistortChat;
+import com.dre.brewery.*;
 import com.dre.brewery.api.events.barrel.BarrelDestroyEvent;
 import com.dre.brewery.configuration.ConfigManager;
 import com.dre.brewery.configuration.files.Config;
@@ -38,12 +34,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.block.BlockBreakEvent;
-import org.bukkit.event.block.BlockBurnEvent;
-import org.bukkit.event.block.BlockPistonExtendEvent;
-import org.bukkit.event.block.BlockPistonRetractEvent;
-import org.bukkit.event.block.BlockPlaceEvent;
-import org.bukkit.event.block.SignChangeEvent;
+import org.bukkit.event.block.*;
 
 public class BlockListener implements Listener {
 

--- a/src/main/java/com/dre/brewery/recipe/BCauldronRecipe.java
+++ b/src/main/java/com/dre/brewery/recipe/BCauldronRecipe.java
@@ -113,7 +113,7 @@ public class BCauldronRecipe {
             if (split.length == 1) {
                 minute = 10;
             } else if (split.length == 2) {
-                minute = BUtil.parseInt(split[1]);
+                minute = BUtil.parseIntOrZero(split[1]);
             } else {
                 Logging.errorLog("cookParticle: '" + entry + "' in: " + recipe.name);
                 return null;

--- a/src/main/java/com/dre/brewery/recipe/BEffect.java
+++ b/src/main/java/com/dre/brewery/recipe/BEffect.java
@@ -97,21 +97,21 @@ public class BEffect implements Cloneable {
 
     private void setLvl(String[] range) {
         if (range.length == 1) {
-            maxlvl = (short) BUtil.parseInt(range[0]);
+            maxlvl = (short) BUtil.getRandomIntInRange(range[0]);
             minlvl = 1;
         } else {
-            maxlvl = (short) BUtil.parseInt(range[1]);
-            minlvl = (short) BUtil.parseInt(range[0]);
+            maxlvl = (short) BUtil.getRandomIntInRange(range[1]);
+            minlvl = (short) BUtil.getRandomIntInRange(range[0]);
         }
     }
 
     private void setDuration(String[] range) {
         if (range.length == 1) {
-            maxduration = (short) BUtil.parseInt(range[0]);
+            maxduration = (short) BUtil.getRandomIntInRange(range[0]);
             minduration = (short) (maxduration / 8);
         } else {
-            maxduration = (short) BUtil.parseInt(range[1]);
-            minduration = (short) BUtil.parseInt(range[0]);
+            maxduration = (short) BUtil.getRandomIntInRange(range[1]);
+            minduration = (short) BUtil.getRandomIntInRange(range[0]);
         }
     }
 

--- a/src/main/java/com/dre/brewery/recipe/BRecipe.java
+++ b/src/main/java/com/dre/brewery/recipe/BRecipe.java
@@ -180,7 +180,7 @@ public class BRecipe implements Cloneable {
             int[] cmData = new int[3];
             for (int i = 0; i < 3; i++) {
                 if (cmdParts.length > i) {
-                    cmData[i] = BUtil.parseInt(cmdParts[i]);
+                    cmData[i] = BUtil.getRandomIntInRange(cmdParts[i]);
                 } else {
                     cmData[i] = i == 0 ? 0 : cmData[i - 1];
                 }
@@ -222,7 +222,7 @@ public class BRecipe implements Cloneable {
             String[] ingredParts = item.split("/");
             int amount = 1;
             if (ingredParts.length == 2) {
-                amount = BUtil.parseInt(ingredParts[1]);
+                amount = BUtil.getRandomIntInRange(ingredParts[1]);
                 if (amount < 1) {
                     Logging.errorLog(recipeId + ": Invalid Item Amount: " + ingredParts[1]);
                     return null;
@@ -280,7 +280,7 @@ public class BRecipe implements Cloneable {
             Material mat = MaterialUtil.getMaterialSafely(matParts[0]);
             short durability = -1;
             if (matParts.length == 2) {
-                durability = (short) BUtil.parseInt(matParts[1]);
+                durability = (short) BUtil.getRandomIntInRange(matParts[1]);
             }
             if (mat == null && Hook.VAULT.isEnabled()) {
                 try {

--- a/src/main/java/com/dre/brewery/storage/BData.java
+++ b/src/main/java/com/dre/brewery/storage/BData.java
@@ -174,7 +174,7 @@ public class BData {
                     boolean stat = section.getBoolean(uid + ".stat", false);
                     int lastUpdate = section.getInt(uid + ".lastUpdate", 0);
 
-                    Brew.loadLegacy(ingredients, BUtil.parseInt(uid), quality, alc, distillRuns, ageTime, BarrelWoodType.fromAny(wood), recipe, unlabeled, persistent, stat, lastUpdate);
+                    Brew.loadLegacy(ingredients, Integer.parseInt(uid), quality, alc, distillRuns, ageTime, BarrelWoodType.fromAny(wood), recipe, unlabeled, persistent, stat, lastUpdate);
                 }
             }
 
@@ -265,7 +265,7 @@ public class BData {
             if (m == null) continue;
             SimpleItem item;
             if (matSplit.length == 2) {
-                item = new SimpleItem(m, (short) BUtil.parseInt(matSplit[1]));
+                item = new SimpleItem(m, (short) BUtil.parseIntOrZero(matSplit[1]));
             } else {
                 item = new SimpleItem(m);
             }
@@ -357,8 +357,7 @@ public class BData {
                 if (block != null) {
                     String[] splitted = block.split("/");
                     if (splitted.length == 3) {
-
-                        Block worldBlock = world.getBlockAt(BUtil.parseInt(splitted[0]), BUtil.parseInt(splitted[1]), BUtil.parseInt(splitted[2]));
+                        Block worldBlock = world.getBlockAt(Integer.parseInt(splitted[0]), Integer.parseInt(splitted[1]), Integer.parseInt(splitted[2]));
                         BIngredients ingredients = loadCauldronIng(section, cauldron + ".ingredients");
                         int state = section.getInt(cauldron + ".state", 0);
 
@@ -385,7 +384,7 @@ public class BData {
 
                         // load itemStacks from invSection
                         ConfigurationSection invSection = section.getConfigurationSection(barrel + ".inv");
-                        Block block = world.getBlockAt(BUtil.parseInt(splitted[0]), BUtil.parseInt(splitted[1]), BUtil.parseInt(splitted[2]));
+                        Block block = world.getBlockAt(Integer.parseInt(splitted[0]), Integer.parseInt(splitted[1]), Integer.parseInt(splitted[2]));
                         float time = (float) section.getDouble(barrel + ".time", 0.0);
                         byte sign = (byte) section.getInt(barrel + ".sign", 0);
 
@@ -393,7 +392,9 @@ public class BData {
                         if (section.contains(barrel + ".bounds")) {
                             String[] bds = section.getString(barrel + ".bounds", "").split(",");
                             if (bds.length == 6) {
-                                box = new BoundingBox(BUtil.parseInt(bds[0]), BUtil.parseInt(bds[1]), BUtil.parseInt(bds[2]), BUtil.parseInt(bds[3]), BUtil.parseInt(bds[4]), BUtil.parseInt(bds[5]));
+                                box = BoundingBox.fromPoints(
+                                    Arrays.stream(bds).mapToInt(Integer::parseInt).toArray()
+                                );
                             }
                         } else if (section.contains(barrel + ".st")) {
                             // Convert from Stair and Wood Locations to BoundingBox
@@ -408,7 +409,7 @@ public class BData {
                             if (woLength > 1) {
                                 System.arraycopy(wo, 0, points, st.length, woLength);
                             }
-                            int[] locs = Arrays.stream(points).mapToInt(s -> BUtil.parseInt(s)).toArray();
+                            int[] locs = Arrays.stream(points).mapToInt(Integer::parseInt).toArray();
                             try {
                                 box = BoundingBox.fromPoints(locs);
                             } catch (Exception e) {
@@ -447,12 +448,12 @@ public class BData {
                 if (loc != null) {
                     String[] splitted = loc.split("/");
                     if (splitted.length == 5) {
+                        double x = Double.parseDouble(splitted[0]);
+                        double y = Double.parseDouble(splitted[1]);
+                        double z = Double.parseDouble(splitted[2]);
+                        float pitch = Float.parseFloat(splitted[3]);
+                        float yaw = Float.parseFloat(splitted[4]);
 
-                        double x = BUtil.parseDouble(splitted[0]);
-                        double y = BUtil.parseDouble(splitted[1]);
-                        double z = BUtil.parseDouble(splitted[2]);
-                        float pitch = BUtil.parseFloat(splitted[3]);
-                        float yaw = BUtil.parseFloat(splitted[4]);
                         Location location = new Location(world, x, y, z, yaw, pitch);
 
                         initWakeups.add(new Wakeup(location));

--- a/src/main/java/com/dre/brewery/storage/DataManager.java
+++ b/src/main/java/com/dre/brewery/storage/DataManager.java
@@ -38,7 +38,6 @@ import com.dre.brewery.storage.impls.SQLiteStorage;
 import com.dre.brewery.storage.interfaces.ExternallyAutoSavable;
 import com.dre.brewery.storage.interfaces.SerializableThing;
 import com.dre.brewery.storage.records.BreweryMiscData;
-import com.dre.brewery.utility.BUtil;
 import com.dre.brewery.utility.Logging;
 import lombok.Getter;
 import org.bukkit.Bukkit;

--- a/src/main/java/com/dre/brewery/storage/impls/FlatFileStorage.java
+++ b/src/main/java/com/dre/brewery/storage/impls/FlatFileStorage.java
@@ -188,10 +188,10 @@ public class FlatFileStorage extends DataManager {
             return null;
         }
 
-        List<Integer> bounds = Arrays.stream(
+        int[] bounds = Arrays.stream(
                 dataFile.getString(path + ".bounds").split(",")
             )
-            .map(Integer::parseInt).toList();
+            .mapToInt(Integer::parseInt).toArray();
 
         BoundingBox boundingBox = BoundingBox.fromPoints(bounds);
         float time = (float) dataFile.getDouble(path + ".time", 0.0);

--- a/src/main/java/com/dre/brewery/utility/BUtil.java
+++ b/src/main/java/com/dre/brewery/utility/BUtil.java
@@ -45,10 +45,6 @@ import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -56,6 +52,8 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public final class BUtil {
 
@@ -67,6 +65,7 @@ public final class BUtil {
 
     private static final String WITH_DELIMITER = "((?<=%1$s)|(?=%1$s))";
     private static final MinecraftVersion VERSION = BreweryPlugin.getMCVersion();
+    private static final Pattern RANGE_PATTERN = Pattern.compile("([-+]?\\d+)\\.\\.([-+]?\\d+)");
 
     /**
      * Check if the Chunk of a Block is loaded !without loading it in the process!
@@ -239,22 +238,6 @@ public final class BUtil {
         return list.stream().map(it -> getEnumByName(mapToEnum, it.toString())).toList();
     }
 
-    /**
-     * Load a String from config, if found a List, will return the first String
-     */
-    @Nullable
-    public static String loadCfgString(ConfigurationSection cfg, String path) {
-        if (cfg.isString(path)) {
-            return cfg.getString(path);
-        } else if (cfg.isList(path)) {
-            List<String> list = cfg.getStringList(path);
-            if (!list.isEmpty()) {
-                return list.get(0);
-            }
-        }
-        return null;
-    }
-
     /* **************************************** */
     /* *********                      ********* */
     /* *********     String Utils     ********* */
@@ -418,7 +401,7 @@ public final class BUtil {
             String[] drainSplit = materialString.split("/");
             if (drainSplit.length > 1) {
                 Material mat = MaterialUtil.getMaterialSafely(drainSplit[0]);
-                int strength = BUtil.parseInt(drainSplit[1]);
+                int strength = BUtil.parseIntOrZero(drainSplit[1]);
 //                if (mat == null && hasVault && strength > 0) {
 //                    try {
 //                        net.milkbowl.vault.item.ItemInfo vaultItem = net.milkbowl.vault.item.Items.itemByString(drainSplit[0]);
@@ -475,73 +458,63 @@ public final class BUtil {
         return worldName;
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
-    public static void saveFile(InputStream in, File dest, String name, boolean overwrite) throws IOException {
-        if (in == null) return;
-        if (!dest.exists()) {
-            dest.mkdirs();
-        }
-        File result = new File(dest, name);
-        if (result.exists()) {
-            if (overwrite) {
-                result.delete();
-            } else {
-                return;
-            }
-        }
-
-        OutputStream out = new FileOutputStream(result);
-        byte[] buffer = new byte[1024];
-
-        int length;
-        //copy the file content in bytes
-        while ((length = in.read(buffer)) > 0) {
-            out.write(buffer, 0, length);
-        }
-
-        in.close();
-        out.close();
-    }
-
-
-    public static int parseInt(String string) {
+    public static int getRandomIntInRange(String string) {
         if (string == null) {
             return 0;
         }
+
         try {
+            Matcher matcher = RANGE_PATTERN.matcher(string);
 
-            if (!string.contains("-")) return Integer.parseInt(string); // Default behaviour
+            if (!matcher.matches()) {
+                return parseIntOrZero(string);
+            }
 
-            // random number in range
+            int lowerBound = Integer.parseInt(matcher.group(1));
+            int upperBound = Integer.parseInt(matcher.group(2));
+
             Random rand = new Random();
-            String[] split = string.split("-");
-            int lowerbound = Integer.parseInt(split[0]);
-            int upperbound = Integer.parseInt(split[1]);
-            return rand.nextInt(upperbound - lowerbound + 1) + lowerbound;
-
+            return rand.nextInt(upperBound - lowerBound + 1) + lowerBound;
         } catch (NumberFormatException ignored) {
+            Logging.debugLog("Could not parse integer range: " + string);
+        }
+
+        return 0;
+    }
+
+    public static int parseIntOrZero(String string) {
+        if (string == null) {
+            return 0;
+        }
+
+        try {
+            return Integer.parseInt(string);
+        } catch (NumberFormatException ignored) {
+            Logging.debugLog("Could not parse integer: " + string);
             return 0;
         }
     }
 
-    public static double parseDouble(String string) {
+    public static double parseDoubleOrZero(String string) {
         if (string == null) {
             return 0;
         }
         try {
             return Double.parseDouble(string);
         } catch (NumberFormatException ignored) {
+            Logging.debugLog("Could not parse double: " + string);
             return 0;
         }
     }
 
-    public static float parseFloat(String string) {
+    public static float parseFloatOrZero(String string) {
         if (string == null) {
             return 0;
         }
         try {
             return Float.parseFloat(string);
         } catch (NumberFormatException ignored) {
+            Logging.debugLog("Could not parse float: " + string);
             return 0;
         }
     }


### PR DESCRIPTION
* Rename `parseInt` to `getRandomIntInRange`, change the format of defining ranges from `(number)-(number)` to `(number)..(number)` and support negative values.
* Replace some unnecessary calls to `BUtil.getRandomIntInRange` with appropriate alternatives.
* Add some debug logs to BUtil's number functions.
* Replace `map(Integer::parseInt)` with `mapToInt(Integer::parseInt)` in some places.
