### PR TITLE
Allow custom translations

### DIFF
--- a/src/main/java/com/dre/brewery/configuration/ConfigHead.java
+++ b/src/main/java/com/dre/brewery/configuration/ConfigHead.java
@@ -154,7 +154,7 @@ public class ConfigHead {
         if (!options.useLangFileName()) {
             return DATA_FOLDER.resolve(options.value());
         } else {
-            return DATA_FOLDER.resolve("languages/" + TranslationManager.getInstance().getActiveTranslation().getFilename());
+            return DATA_FOLDER.resolve("languages/" + TranslationManager.getInstance().getActiveTranslation().fileName());
         }
     }
 

--- a/src/main/java/com/dre/brewery/configuration/configurer/ConfigTranslations.java
+++ b/src/main/java/com/dre/brewery/configuration/configurer/ConfigTranslations.java
@@ -44,6 +44,7 @@ public class ConfigTranslations {
                 return;
             }
             try (InputStream defaultInputStream = ConfigTranslations.class.getResourceAsStream("/config-langs/" + Translation.EN.fileName())) {
+                Logging.log("Could not find config translation, using default: ");
                 if (defaultInputStream == null) {
                     throw new IOException("Couldn't find default translation file");
                 }

--- a/src/main/java/com/dre/brewery/configuration/configurer/ConfigTranslations.java
+++ b/src/main/java/com/dre/brewery/configuration/configurer/ConfigTranslations.java
@@ -37,11 +37,18 @@ public class ConfigTranslations {
     }
 
     public ConfigTranslations(Translation activeTranslation, Yaml yamlInstance) {
-        try (InputStream inputStream = this.getClass()
-            .getClassLoader()
-            .getResourceAsStream("config-langs/" + activeTranslation.fileName())) {
-
-            translations = yamlInstance.load(inputStream);
+        try (InputStream inputStream = ConfigTranslations.class
+            .getResourceAsStream("/config-langs/" + activeTranslation.fileName())) {
+            if (inputStream != null) {
+                translations = yamlInstance.load(inputStream);
+                return;
+            }
+            try (InputStream defaultInputStream = ConfigTranslations.class.getResourceAsStream("/config-langs/" + Translation.EN.fileName())) {
+                if (defaultInputStream == null) {
+                    throw new IOException("Couldn't find default translation file");
+                }
+                translations = yamlInstance.load(defaultInputStream);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/dre/brewery/configuration/configurer/ConfigTranslations.java
+++ b/src/main/java/com/dre/brewery/configuration/configurer/ConfigTranslations.java
@@ -39,7 +39,7 @@ public class ConfigTranslations {
     public ConfigTranslations(Translation activeTranslation, Yaml yamlInstance) {
         try (InputStream inputStream = this.getClass()
             .getClassLoader()
-            .getResourceAsStream("config-langs/" + activeTranslation.getFilename())) {
+            .getResourceAsStream("config-langs/" + activeTranslation.fileName())) {
 
             translations = yamlInstance.load(inputStream);
         } catch (IOException e) {

--- a/src/main/java/com/dre/brewery/configuration/configurer/ConfigTranslations.java
+++ b/src/main/java/com/dre/brewery/configuration/configurer/ConfigTranslations.java
@@ -44,7 +44,7 @@ public class ConfigTranslations {
                 return;
             }
             try (InputStream defaultInputStream = ConfigTranslations.class.getResourceAsStream("/config-langs/" + Translation.EN.fileName())) {
-                Logging.log("Could not find config translation, using default: ");
+                Logging.log("Could not find config translation, using default");
                 if (defaultInputStream == null) {
                     throw new IOException("Couldn't find default translation file");
                 }

--- a/src/main/java/com/dre/brewery/configuration/configurer/Translation.java
+++ b/src/main/java/com/dre/brewery/configuration/configurer/Translation.java
@@ -31,7 +31,6 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.stream.Stream;
 
 /**
  * List of the available translation<br />
@@ -55,25 +54,31 @@ public record Translation(String fileName) {
     }
 
     private static List<Translation> compileTranslations() {
-        Stream<String> languageFiles;
         try {
-            URI uri = Translation.class.getResource("/resources").toURI();
+            URI uri = Translation.class.getResource("/languages").toURI();
             Path myPath;
             if (uri.getScheme().equals("jar")) {
                 try (FileSystem fileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap())) {
-                    myPath = fileSystem.getPath("/resources");
-                    languageFiles = Files.walk(myPath, 1).map(Path::getFileName).map(Path::toString);
+                    myPath = fileSystem.getPath("/languages");
+                    return Files.walk(myPath, 1)
+                        .map(Path::getFileName)
+                        .map(Path::toString)
+                        .filter(filename -> filename.endsWith(".yml"))
+                        .map(Translation::new)
+                        .toList();
                 }
             } else {
                 myPath = Paths.get(uri);
-                languageFiles = Files.walk(myPath, 1).map(Path::getFileName).map(Path::toString);
+                return Files.walk(myPath, 1)
+                    .map(Path::getFileName)
+                    .map(Path::toString)
+                    .filter(filename -> filename.endsWith(".yml"))
+                    .map(Translation::new)
+                    .toList();
             }
         } catch (URISyntaxException | IOException e) {
             throw new RuntimeException(e);
         }
-        return languageFiles
-            .filter(filename -> filename.endsWith(".yml"))
-            .map(Translation::new)
-            .toList();
+
     }
 }

--- a/src/main/java/com/dre/brewery/configuration/configurer/Translation.java
+++ b/src/main/java/com/dre/brewery/configuration/configurer/Translation.java
@@ -31,6 +31,7 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Stream;
 
 public record Translation(String fileName) {
 
@@ -54,25 +55,25 @@ public record Translation(String fileName) {
             if (uri.getScheme().equals("jar")) {
                 try (FileSystem fileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap())) {
                     myPath = fileSystem.getPath("/languages");
-                    return Files.walk(myPath, 1)
-                        .map(Path::getFileName)
-                        .map(Path::toString)
-                        .filter(filename -> filename.endsWith(".yml"))
-                        .map(Translation::new)
-                        .toList();
+                    return fromPaths(Files.walk(myPath, 1));
                 }
             } else {
                 myPath = Paths.get(uri);
-                return Files.walk(myPath, 1)
-                    .map(Path::getFileName)
-                    .map(Path::toString)
-                    .filter(filename -> filename.endsWith(".yml"))
-                    .map(Translation::new)
-                    .toList();
+                return fromPaths(Files.walk(myPath, 1));
+
             }
         } catch (URISyntaxException | IOException e) {
             throw new RuntimeException(e);
         }
 
+    }
+
+    public static List<Translation> fromPaths(Stream<Path> pathStream) {
+        return pathStream
+            .map(Path::getFileName)
+            .map(Path::toString)
+            .filter(filename -> filename.endsWith(".yml"))
+            .map(Translation::new)
+            .toList();
     }
 }

--- a/src/main/java/com/dre/brewery/configuration/configurer/Translation.java
+++ b/src/main/java/com/dre/brewery/configuration/configurer/Translation.java
@@ -32,15 +32,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
-/**
- * List of the available translation<br />
- * Should we even use an enum here?<br />
- * <br />
- * The comments can be found under {@code langs/LANGUAGE.yml}
- */
 public record Translation(String fileName) {
 
-    // Languages added should have a config and a lang translation (resources/config-langs/, resources/languages/)
+    // Languages added should have a language translation, and may have a config translation
 
     public static final Translation EN = new Translation("en.yml");
     private static final List<Translation> DEFAULT_TRANSLATIONS = compileTranslations();

--- a/src/main/java/com/dre/brewery/configuration/configurer/TranslationManager.java
+++ b/src/main/java/com/dre/brewery/configuration/configurer/TranslationManager.java
@@ -66,13 +66,7 @@ public class TranslationManager {
         try (InputStream inputStream = Files.newInputStream(ConfigManager.getFilePath(Config.class))) {
             Map<String, String> data = yaml.loadAs(inputStream, Map.class);
             if (data != null) {
-                Translation trans = BUtil.getEnumByName(Translation.class, data.get("language"));
-
-                if (trans != null) {
-                    this.activeTranslation = trans;
-                } else {
-                    Logging.warningLog("Invalid language in config.yml: &6" + data.get("language"));
-                }
+                this.activeTranslation = Translation.getTranslation(data.get("language"));
             }
         } catch (IOException e) {
             Logging.debugLog("Error reading YAML file: " + e.getMessage());
@@ -82,7 +76,7 @@ public class TranslationManager {
         this.fallbackTranslations = new ConfigTranslations(fallbackTranslation, yaml);
 
         // Create lang files from /resources/languages
-        for (Translation translation : Translation.values()) {
+        for (Translation translation : Translation.getDefaultTranslations()) {
             createLanguageFile(translation);
         }
     }
@@ -107,7 +101,7 @@ public class TranslationManager {
     }
 
     public void createLanguageFile(Translation translation) {
-        ConfigManager.createFileFromResources("languages/" + translation.getFilename(), dataFolder.toPath().resolve("languages").resolve(translation.getFilename()));
+        ConfigManager.createFileFromResources("languages/" + translation.fileName(), dataFolder.toPath().resolve("languages").resolve(translation.fileName()));
     }
 
     // Okaeri would do this normally, but since default values in Lang changes based on language,
@@ -121,8 +115,8 @@ public class TranslationManager {
         ConfigHead tempHead = new ConfigHead(); // Prevent polluting ConfigManager global state
 
         Lang fallback = loadFromResources(tempHead, Translation.EN);
-        for (Translation trans : Translation.values()) {
-            String langFilePathStr = "languages/" + trans.getFilename();
+        for (Translation trans : Translation.getDefaultTranslations()) {
+            String langFilePathStr = "languages/" + trans.fileName();
             Path langFilePath = dataFolder.toPath().resolve(langFilePathStr);
 
             Lang langFromFile = tempHead.createConfig(Lang.class, langFilePath);
@@ -140,7 +134,7 @@ public class TranslationManager {
     // A bit of a hack, but avoids having to modify Okaeri
     @Nullable
     private Lang loadFromResources(ConfigHead tempHead, Translation translation) {
-        String langFilePathStr = "languages/" + translation.getFilename();
+        String langFilePathStr = "languages/" + translation.fileName();
         Path langFilePath = dataFolder.toPath().resolve(langFilePathStr);
 
         Lang langFromResources = tempHead.createConfig(Lang.class, langFilePath);


### PR DESCRIPTION
With this change, it should be as simple as writing your own language configuration file, and then switching language. Config translations are handled differently though, only read from internal resources, so there's no change there except for defaulting to english config file translations.