### PR TITLE
Fix small barrel partly breaking from sign issue

### DIFF
--- a/src/main/java/com/dre/brewery/utility/BUtil.java
+++ b/src/main/java/com/dre/brewery/utility/BUtil.java
@@ -335,7 +335,7 @@ public final class BUtil {
             if (barrel2 != null) {
                 if (!barrel2.isLarge()) {
                     if (barrel2.hasPermsDestroy(player, block, reason)) {
-                        barrel2.remove(null, player, true);
+                        barrel2.remove(block, player, true);
                         return true;
                     } else {
                         return false;


### PR DESCRIPTION
Seems like changing one method argument fixes the issue. I'm not going to patch that method, something else might break

fixes #108 