### PR TITLE
Change barrel registration algorithm and remove reduntant code

### DIFF
--- a/src/main/java/com/dre/brewery/BarrelBody.java
+++ b/src/main/java/com/dre/brewery/BarrelBody.java
@@ -32,6 +32,9 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * The Blocks that make up a Barrel in the World
  */
@@ -41,11 +44,9 @@ public abstract class BarrelBody {
 
     protected final Block spigot;
     protected final BoundingBox bounds;
-    protected byte signoffset;
 
-    public BarrelBody(Block spigot, byte signoffset) {
+    public BarrelBody(Block spigot) {
         this.spigot = spigot;
-        this.signoffset = signoffset;
         this.bounds = new BoundingBox(0, 0, 0, 0, 0, 0);
 
         if (MinecraftVersion.isFolia()) { // Issues#70
@@ -61,9 +62,8 @@ public abstract class BarrelBody {
     /**
      * Loading from file
      */
-    public BarrelBody(Block spigot, byte signoffset, BoundingBox bounds) {
+    public BarrelBody(Block spigot, BoundingBox bounds) {
         this.spigot = spigot;
-        this.signoffset = signoffset;
         this.bounds = bounds;
         if (this.bounds == null || this.bounds.isBad()) {
             // If loading from old data, or block locations are missing, or other error, regenerate BoundingBox
@@ -76,14 +76,6 @@ public abstract class BarrelBody {
                 BreweryPlugin.getScheduler().runTask(spigot.getLocation(), this::regenerateBounds);
             }
         }
-    }
-
-
-    /**
-     * If the Sign of a Large Barrel gets destroyed, set signOffset to 0
-     */
-    public void destroySign() {
-        signoffset = 0;
     }
 
 
@@ -160,47 +152,21 @@ public abstract class BarrelBody {
     }
 
     /**
-     * Returns true if the Offset of the clicked Sign matches the Barrel.
-     * <p>This prevents adding another sign to the barrel and clicking that.
-     */
-    public boolean isSignOfBarrel(byte offset) {
-        return offset == 0 || signoffset == 0 || signoffset == offset;
-    }
-
-    /**
-     * returns the Sign of a large barrel, the spigot if there is none
-     */
-    public Block getSignOfSpigot() {
-        if (signoffset != 0) {
-            if (BarrelAsset.isBarrelAsset(BarrelAsset.SIGN, spigot.getType())) {
-                return spigot;
-            }
-
-            Block relative = spigot.getRelative(0, signoffset, 0);
-            if (BarrelAsset.isBarrelAsset(BarrelAsset.SIGN, relative.getType())) {
-                return relative;
-            } else {
-                signoffset = 0;
-            }
-        }
-        return spigot;
-    }
-
-    /**
      * returns the fence above/below a block, itself if there is none
      */
-    public static Block getSpigotOfSign(Block block) {
-
+    public static Set<Block> getSpigotOfSign(Block block) {
+        Set<Block> output = new HashSet<>();
+        output.add(block);
         int y = -2;
         while (y <= 1) {
             // Fence and Netherfence
             Block relative = block.getRelative(0, y, 0);
             if (BarrelAsset.isBarrelAsset(BarrelAsset.FENCE, relative.getType())) {
-                return relative;
+                output.add(relative);
             }
             y++;
         }
-        return block;
+        return output;
     }
 
     public abstract void remove(@Nullable Block broken, @Nullable Player breaker, boolean dropItems);

--- a/src/main/java/com/dre/brewery/BreweryPlugin.java
+++ b/src/main/java/com/dre/brewery/BreweryPlugin.java
@@ -59,6 +59,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.command.CommandMap;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.event.HandlerList;
@@ -154,10 +155,12 @@ public final class BreweryPlugin extends JavaPlugin {
 
         // Load objects
         DataManager.loadMiscData(dataManager.getBreweryMiscData());
-        Barrel.getBarrels().addAll(dataManager.getAllBarrels()
-            .stream()
-            .filter(Objects::nonNull)
-            .toList());
+        for(World world : Bukkit.getWorlds()) {
+            Barrel.addBarrels(dataManager.getAllBarrels(world)
+                .stream()
+                .filter(Objects::nonNull)
+                .toList());
+        }
         BCauldron.getBcauldrons().putAll(dataManager.getAllCauldrons().stream()
             .filter(Objects::nonNull)
             .collect(Collectors.toMap(

--- a/src/main/java/com/dre/brewery/commands/subcommands/ShowStatsCommand.java
+++ b/src/main/java/com/dre/brewery/commands/subcommands/ShowStatsCommand.java
@@ -40,7 +40,7 @@ public class ShowStatsCommand implements SubCommand {
 
         Logging.msg(sender, "Drunk Players: " + BPlayer.numDrunkPlayers());
         Logging.msg(sender, "Brews created: " + BreweryPlugin.getInstance().getBreweryStats().brewsCreated);
-        Logging.msg(sender, "Barrels built: " + Barrel.barrels.size());
+        Logging.msg(sender, "Barrels built: " + Barrel.getBarrels().size());
         Logging.msg(sender, "Cauldrons boiling: " + BCauldron.bcauldrons.size());
         Logging.msg(sender, "Number of Recipes: " + BRecipe.getAllRecipes().size());
         Logging.msg(sender, "Wakeups: " + Wakeup.wakeups.size());

--- a/src/main/java/com/dre/brewery/integration/barrel/LWCBarrel.java
+++ b/src/main/java/com/dre/brewery/integration/barrel/LWCBarrel.java
@@ -44,9 +44,9 @@ public class LWCBarrel {
 
     public static boolean denyDestroy(Player player, Barrel barrel) {
         LWC lwc = LWC.getInstance();
-        Block sign = barrel.getSignOfSpigot();
+        Block spigot = barrel.getSpigot();
         //if (!Boolean.parseBoolean(lwc.resolveProtectionConfiguration(sign, "ignoreBlockDestruction"))) {
-        Protection protection = lwc.findProtection(sign);
+        Protection protection = lwc.findProtection(spigot);
         if (protection != null) {
             boolean canAccess = lwc.canAccessProtection(player, protection);
             boolean canAdmin = lwc.canAdminProtection(player, protection);
@@ -102,7 +102,7 @@ public class LWCBarrel {
 
     // If a Barrel is destroyed without player
     public static void remove(Barrel barrel) {
-        Protection protection = LWC.getInstance().findProtection(barrel.getSignOfSpigot());
+        Protection protection = LWC.getInstance().findProtection(barrel.getSpigot());
         if (protection != null) {
             protection.remove();
         }
@@ -110,13 +110,13 @@ public class LWCBarrel {
 
     // Returns true if the block that exploded should not be removed
     public static boolean denyExplosion(Barrel barrel) {
-        Protection protection = LWC.getInstance().findProtection(barrel.getSignOfSpigot());
+        Protection protection = LWC.getInstance().findProtection(barrel.getSpigot());
 
         return protection != null && !protection.hasFlag(Flag.Type.ALLOWEXPLOSIONS);
     }
 
     // Returns true if the block that was destroyed should not be removed
     public static boolean denyDestroyOther(Barrel barrel) {
-        return LWC.getInstance().findProtection(barrel.getSignOfSpigot()) != null;
+        return LWC.getInstance().findProtection(barrel.getSpigot()) != null;
     }
 }

--- a/src/main/java/com/dre/brewery/integration/bstats/BreweryStats.java
+++ b/src/main/java/com/dre/brewery/integration/bstats/BreweryStats.java
@@ -79,7 +79,7 @@ public class BreweryStats {
             Metrics metrics = new Metrics(BreweryPlugin.getInstance(), BSTATS_ID);
             metrics.addCustomChart(new SingleLineChart("drunk_players", BPlayer::numDrunkPlayers));
             metrics.addCustomChart(new SingleLineChart("brews_in_existence", () -> brewsCreated));
-            metrics.addCustomChart(new SingleLineChart("barrels_built", Barrel.barrels::size));
+            metrics.addCustomChart(new SingleLineChart("barrels_built", Barrel.getBarrels()::size));
             metrics.addCustomChart(new SingleLineChart("cauldrons_boiling", BCauldron.bcauldrons::size));
             metrics.addCustomChart(new AdvancedPie("brew_quality", () -> {
                 Map<String, Integer> map = new HashMap<>(8);

--- a/src/main/java/com/dre/brewery/integration/bstats/BreweryXStats.java
+++ b/src/main/java/com/dre/brewery/integration/bstats/BreweryXStats.java
@@ -108,7 +108,7 @@ public class BreweryXStats {
             metrics.addCustomChart(new SimplePie("branch", this::getBranch));
 
             metrics.addCustomChart(new SingleLineChart("drunk_players", BPlayer::numDrunkPlayers));
-            metrics.addCustomChart(new SingleLineChart("barrels_built", Barrel.barrels::size));
+            metrics.addCustomChart(new SingleLineChart("barrels_built", Barrel.getBarrels()::size));
             metrics.addCustomChart(new SingleLineChart("cauldrons_boiling", BCauldron.bcauldrons::size));
 
         } catch (Exception | LinkageError e) {

--- a/src/main/java/com/dre/brewery/integration/listeners/IntegrationListener.java
+++ b/src/main/java/com/dre/brewery/integration/listeners/IntegrationListener.java
@@ -153,7 +153,7 @@ public class IntegrationListener implements Listener {
 
                 // If the Clicked Block was the Sign, LWC already knows and we dont need to do anything here
                 if (!BarrelAsset.isBarrelAsset(BarrelAsset.SIGN, event.getClickedBlock().getType())) {
-                    Block sign = event.getBarrel().getSignOfSpigot();
+                    Block sign = event.getBarrel().getSpigot();
                     // If the Barrel does not have a Sign, it cannot be locked
                     if (!sign.equals(event.getClickedBlock())) {
                         Player player = event.getPlayer();

--- a/src/main/java/com/dre/brewery/listeners/WorldListener.java
+++ b/src/main/java/com/dre/brewery/listeners/WorldListener.java
@@ -26,6 +26,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.world.WorldLoadEvent;
+import org.bukkit.event.world.WorldUnloadEvent;
 
 import java.util.Collection;
 
@@ -43,7 +44,7 @@ public class WorldListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
-    public void onWorldUnLoad(WorldLoadEvent event) {
+    public void onWorldUnLoad(WorldUnloadEvent event) {
         Collection<Barrel> barrels = Barrel.getBarrels(event.getWorld());
         barrels.forEach(dataManager::saveBarrel);
     }

--- a/src/main/java/com/dre/brewery/listeners/WorldListener.java
+++ b/src/main/java/com/dre/brewery/listeners/WorldListener.java
@@ -1,0 +1,50 @@
+/*
+ * BreweryX Bukkit-Plugin for an alternate brewing process
+ * Copyright (C) 2024-2025 The Brewery Team
+ *
+ * This file is part of BreweryX.
+ *
+ * BreweryX is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BreweryX is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BreweryX. If not, see <http://www.gnu.org/licenses/gpl-3.0.html>.
+ */
+
+package com.dre.brewery.listeners;
+
+import com.dre.brewery.Barrel;
+import com.dre.brewery.storage.DataManager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.WorldLoadEvent;
+
+import java.util.Collection;
+
+public class WorldListener implements Listener {
+
+    private final DataManager dataManager;
+
+    public WorldListener(DataManager dataManager) {
+        this.dataManager = dataManager;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onWorldLoad(WorldLoadEvent event) {
+        Barrel.addBarrels(dataManager.getAllBarrels(event.getWorld()));
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onWorldUnLoad(WorldLoadEvent event) {
+        Collection<Barrel> barrels = Barrel.getBarrels(event.getWorld());
+        barrels.forEach(dataManager::saveBarrel);
+    }
+}

--- a/src/main/java/com/dre/brewery/storage/BData.java
+++ b/src/main/java/com/dre/brewery/storage/BData.java
@@ -386,7 +386,6 @@ public class BData {
                         ConfigurationSection invSection = section.getConfigurationSection(barrel + ".inv");
                         Block block = world.getBlockAt(Integer.parseInt(splitted[0]), Integer.parseInt(splitted[1]), Integer.parseInt(splitted[2]));
                         float time = (float) section.getDouble(barrel + ".time", 0.0);
-                        byte sign = (byte) section.getInt(barrel + ".sign", 0);
 
                         BoundingBox box = null;
                         if (section.contains(barrel + ".bounds")) {
@@ -421,10 +420,10 @@ public class BData {
 
                         Barrel b;
                         if (invSection != null) {
-                            b = new Barrel(block, sign, bbox, invSection.getValues(true), time, UUID.randomUUID());
+                            b = new Barrel(block, bbox, invSection.getValues(true), time, UUID.randomUUID());
                         } else {
                             // Barrel has no inventory
-                            b = new Barrel(block, sign, bbox, Collections.emptyMap(), time, UUID.randomUUID());
+                            b = new Barrel(block, bbox, Collections.emptyMap(), time, UUID.randomUUID());
                         }
 
                         initBarrels.add(b);
@@ -474,7 +473,7 @@ public class BData {
             BCauldron.bcauldrons.putAll(initCauldrons);
         }
         if (!initBarrels.isEmpty()) {
-            Barrel.barrels.addAll(initBarrels);
+            Barrel.addBarrels(initBarrels);
         }
 
         if (!initWakeups.isEmpty()) {

--- a/src/main/java/com/dre/brewery/storage/DataManager.java
+++ b/src/main/java/com/dre/brewery/storage/DataManager.java
@@ -83,7 +83,7 @@ public abstract class DataManager {
 
     public abstract Barrel getBarrel(UUID id);
 
-    public abstract Collection<Barrel> getAllBarrels();
+    public abstract Collection<Barrel> getAllBarrels(World world);
 
     public abstract void saveAllBarrels(Collection<Barrel> barrels);
 

--- a/src/main/java/com/dre/brewery/storage/impls/FlatFileStorage.java
+++ b/src/main/java/com/dre/brewery/storage/impls/FlatFileStorage.java
@@ -39,6 +39,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.inventory.ItemStack;
@@ -195,15 +196,14 @@ public class FlatFileStorage extends DataManager {
 
         BoundingBox boundingBox = BoundingBox.fromPoints(bounds);
         float time = (float) dataFile.getDouble(path + ".time", 0.0);
-        byte sign = (byte) dataFile.getInt(path + ".sign", 0);
         ItemStack[] items = BukkitSerialization.itemStackArrayFromBase64(dataFile.getString(path + ".items", null));
 
 
-        return new Barrel(spigotLoc.getBlock(), sign, boundingBox, items, time, id);
+        return new Barrel(spigotLoc.getBlock(), boundingBox, items, time, id);
     }
 
     @Override
-    public Collection<Barrel> getAllBarrels() {
+    public Collection<Barrel> getAllBarrels(World world) {
         ConfigurationSection section = dataFile.getConfigurationSection("barrels");
         if (section == null) {
             return Collections.emptyList();
@@ -213,6 +213,9 @@ public class FlatFileStorage extends DataManager {
 
         for (String key : section.getKeys(false)) {
             Barrel barrel = getBarrel(BUtil.uuidFromString(key));
+            if (!barrel.getSpigot().getWorld().equals(world)) {
+                continue;
+            }
             if (barrel != null) {
                 barrels.add(barrel);
             }
@@ -238,7 +241,6 @@ public class FlatFileStorage extends DataManager {
         dataFile.set(path + ".spigot", serializeLocation(barrel.getSpigot().getLocation()));
         dataFile.set(path + ".bounds", barrel.getBounds().serialize());
         dataFile.set(path + ".time", barrel.getTime());
-        dataFile.set(path + ".sign", barrel.getSignoffset());
         dataFile.set(path + ".items", BukkitSerialization.itemStackArrayToBase64(barrel.getInventory().getContents()));
         save();
     }

--- a/src/main/java/com/dre/brewery/storage/impls/MongoDBStorage.java
+++ b/src/main/java/com/dre/brewery/storage/impls/MongoDBStorage.java
@@ -42,6 +42,7 @@ import com.mongodb.client.model.ReplaceOptions;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Logger;
+import org.bukkit.World;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -165,9 +166,10 @@ public class MongoDBStorage extends DataManager {
     }
 
     @Override
-    public Collection<Barrel> getAllBarrels() {
+    public Collection<Barrel> getAllBarrels(World world) {
         return getAllGeneric("barrels", SerializableBarrel.class).stream()
             .map(SerializableBarrel::toBarrel)
+            .filter(barrel -> barrel.getSpigot().getWorld().equals(world))
             .toList();
     }
 

--- a/src/main/java/com/dre/brewery/storage/impls/MySQLStorage.java
+++ b/src/main/java/com/dre/brewery/storage/impls/MySQLStorage.java
@@ -35,6 +35,7 @@ import com.dre.brewery.storage.records.SerializableCauldron;
 import com.dre.brewery.storage.records.SerializableWakeup;
 import com.dre.brewery.storage.serialization.SQLDataSerializer;
 import com.dre.brewery.utility.Logging;
+import org.bukkit.World;
 import org.jetbrains.annotations.Nullable;
 
 import java.sql.Connection;
@@ -240,9 +241,10 @@ public class MySQLStorage extends DataManager {
     }
 
     @Override
-    public Collection<Barrel> getAllBarrels() {
+    public Collection<Barrel> getAllBarrels(World world) {
         return getAllGeneric("barrels", SerializableBarrel.class).stream()
             .map(SerializableBarrel::toBarrel)
+            .filter(barrel -> barrel.getSpigot().getWorld().equals(world))
             .toList();
     }
 

--- a/src/main/java/com/dre/brewery/storage/impls/SQLiteStorage.java
+++ b/src/main/java/com/dre/brewery/storage/impls/SQLiteStorage.java
@@ -35,6 +35,7 @@ import com.dre.brewery.storage.records.SerializableCauldron;
 import com.dre.brewery.storage.records.SerializableWakeup;
 import com.dre.brewery.storage.serialization.SQLDataSerializer;
 import com.dre.brewery.utility.Logging;
+import org.bukkit.World;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
@@ -252,9 +253,10 @@ public class SQLiteStorage extends DataManager {
     }
 
     @Override
-    public Collection<Barrel> getAllBarrels() {
+    public Collection<Barrel> getAllBarrels(World world) {
         return getAllGeneric("barrels", SerializableBarrel.class).stream()
             .map(SerializableBarrel::toBarrel)
+            .filter(barrel -> barrel.getSpigot().getWorld().equals(world))
             .toList();
     }
 

--- a/src/main/java/com/dre/brewery/storage/records/SerializableBarrel.java
+++ b/src/main/java/com/dre/brewery/storage/records/SerializableBarrel.java
@@ -37,13 +37,12 @@ import java.util.List;
  * @param serializedLocation The Block/Location of the Spigot of the barrel
  * @param bounds             The bounds of the barrel
  * @param time               no idea
- * @param sign               The sign byte offset the barrel
  * @param serializedItems    Serialized ItemStacks 'BukkitSerialization.itemStackArrayToBase64(ItemStack[])'
  */
-public record SerializableBarrel(String id, String serializedLocation, List<Integer> bounds, float time, byte sign,
+public record SerializableBarrel(String id, String serializedLocation, List<Integer> bounds, float time,
                                  String serializedItems) implements SerializableThing {
     public SerializableBarrel(Barrel barrel) {
-        this(barrel.getId().toString(), DataManager.serializeLocation(barrel.getSpigot().getLocation()), barrel.getBounds().serializeToIntList(), barrel.getTime(), barrel.getSignoffset(), BukkitSerialization.itemStackArrayToBase64(barrel.getInventory().getContents()));
+        this(barrel.getId().toString(), DataManager.serializeLocation(barrel.getSpigot().getLocation()), barrel.getBounds().serializeToIntList(), barrel.getTime(), BukkitSerialization.itemStackArrayToBase64(barrel.getInventory().getContents()));
     }
 
     public Barrel toBarrel() {
@@ -51,7 +50,7 @@ public record SerializableBarrel(String id, String serializedLocation, List<Inte
         if (loc == null) {
             return null;
         }
-        return new Barrel(loc.getBlock(), sign, BoundingBox.fromPoints(bounds), BukkitSerialization.itemStackArrayFromBase64(serializedItems), time, BUtil.uuidFromString(id));
+        return new Barrel(loc.getBlock(), BoundingBox.fromPoints(bounds), BukkitSerialization.itemStackArrayFromBase64(serializedItems), time, BUtil.uuidFromString(id));
     }
 
     @Override

--- a/src/main/java/com/dre/brewery/utility/BUtil.java
+++ b/src/main/java/com/dre/brewery/utility/BUtil.java
@@ -31,7 +31,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
 import org.bukkit.Material;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
@@ -332,16 +331,12 @@ public final class BUtil {
         } else if (BarrelAsset.isBarrelAsset(BarrelAsset.SIGN, type)) {
             // remove small Barrels
             Barrel barrel2 = Barrel.getBySpigot(block);
-            if (barrel2 != null) {
-                if (!barrel2.isLarge()) {
-                    if (barrel2.hasPermsDestroy(player, block, reason)) {
-                        barrel2.remove(null, player, true);
-                        return true;
-                    } else {
-                        return false;
-                    }
+            if (barrel2 != null && barrel2.isSmall()) {
+                if (barrel2.hasPermsDestroy(player, block, reason)) {
+                    barrel2.remove(null, player, true);
+                    return true;
                 } else {
-                    barrel2.destroySign();
+                    return false;
                 }
             }
             return true;

--- a/src/main/java/com/dre/brewery/utility/BoundingBox.java
+++ b/src/main/java/com/dre/brewery/utility/BoundingBox.java
@@ -22,7 +22,9 @@ package com.dre.brewery.utility;
 
 import org.bukkit.Location;
 import org.bukkit.block.Block;
+import org.bukkit.util.BlockVector;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class BoundingBox {
@@ -119,5 +121,17 @@ public class BoundingBox {
             maxz = Math.max(locations.get(i + 2), maxz);
         }
         return new BoundingBox(minx, miny, minz, maxx, maxy, maxz);
+    }
+
+    public List<BlockVector> getPositions() {
+        List<BlockVector> output = new ArrayList<>();
+        for (int x = x1; x <= x2; x++) {
+            for (int y = y1; y <= y2; y++) {
+                for (int z = z1; z <= z2; z++) {
+                    output.add(new BlockVector(x, y, z));
+                }
+            }
+        }
+        return output;
     }
 }


### PR DESCRIPTION
Fixes #113

Should be a performance improvement, does take up a bit more storage, but this is probably miniscule compared to what every item in the barrel inventories takes.

As this is quite a major refactor (whops), I might have messed up somewhere.

Here's a list of all the things I did:
- Use HashMap when mapping barrels instead of using lists, much easier access when coding, and probably faster at Barrel amounts larger than 100
- Remove sign offsett thing completely, this property seems reduntant
- Listen to world load / unload events, and register / unregister barrels as needed. (untested and I'm not quite sure how this works)