### PR TITLE
New barrel type distance algorithm

### DIFF
--- a/src/main/java/com/dre/brewery/BIngredients.java
+++ b/src/main/java/com/dre/brewery/BIngredients.java
@@ -449,9 +449,9 @@ public class BIngredients {
 
         return Math.max(quality, 0);
     }
-    // At difficulty 1, distances 0-4 have quality 10, 10, 9, 8, 7
-    // At difficulty 5, distances 0-4 have quality 10, 8, 4, 1, 0
-    // At difficulty 10, distances 0-4 have quality 10, 5, 0, 0, 0
+    // At difficulty 1, distances 0-5 have quality 10, 10, 9, 8, 7, 6
+    // At difficulty 5, distances 0-5 have quality 10, 8, 4, 1, 0, 0
+    // At difficulty 10, distances 0-5 have quality 10, 5, 0, 0, 0, 0
     // See: https://www.desmos.com/calculator/aaoixs2qo7
     private int getWoodQualityNew(BRecipe recipe, BarrelWoodType wood) {
         BarrelWoodType recipeWood = recipe.getWood();
@@ -461,6 +461,7 @@ public class BIngredients {
             case 2 -> 7.75f;
             case 3 -> 6.25f;
             case 4 -> 4.5f;
+            case 5 -> 2.5f;
             default -> 0.0f;
         };
         if (baseQuality == 0.0f) {

--- a/src/main/java/com/dre/brewery/Brew.java
+++ b/src/main/java/com/dre/brewery/Brew.java
@@ -692,11 +692,7 @@ public class Brew implements Cloneable {
 
         // if younger than half a day, it shouldnt get aged form
         if (ageTime > 0.5) {
-            if (wood == BarrelWoodType.ANY) {
-                wood = woodType;
-            } else if (wood != woodType) {
-                woodShift(time, woodType);
-            }
+            woodShift(time, woodType);
             BRecipe recipe = ingredients.getAgeRecipe(wood, ageTime, distillRuns > 0);
             if (recipe != null) {
                 currentRecipe = recipe;
@@ -757,17 +753,22 @@ public class Brew implements Cloneable {
      * Slowly shift the wood of the Brew to the new Type
      */
     public void woodShift(float time, BarrelWoodType to) {
-        if (immutable) return;
+        if (immutable || wood == to) {
+            return;
+        }
+        if (wood == BarrelWoodType.ANY) {
+            wood = to;
+            return;
+        }
+        if (config.isNewBarrelTypeAlgorithm()) {
+            woodShiftNew(time, to);
+            return;
+        }
+
         int fromIndex = wood.getIndex();
         int toIndex = to.getIndex();
 
-        float factor = 1;
-        if (ageTime > 5) {
-            factor = 2;
-        }
-        if (ageTime > 10) {
-            factor += ageTime / 10F;
-        }
+        float factor = woodShiftFactor();
         if (fromIndex > toIndex) {
             fromIndex -= (int) (time / factor);
             if (fromIndex < toIndex) {
@@ -779,6 +780,27 @@ public class Brew implements Cloneable {
                 wood = to;
             }
         }
+    }
+    private void woodShiftNew(float time, BarrelWoodType to) {
+        BarrelWoodType old = wood;
+        float factor = woodShiftFactor();
+        float shift = time / factor;
+        // If the old algorithm would shift by 2 indexes,
+        // shift the barrel type by 1 group (or 1 barrel type within a group)
+        int steps = (int) (2.0f * shift);
+        wood = wood.stepTowards(to, steps);
+        Logging.debugLog(String.format("Shifted wood from %s to %s by %s steps", old, wood, steps));
+        Logging.debugLog(String.format("time=%.3f, factor=%.3f, shift=%.3f", time, factor, shift));
+    }
+    private float woodShiftFactor() {
+        float factor = 1;
+        if (ageTime > 5) {
+            factor = 2;
+        }
+        if (ageTime > 10) {
+            factor += ageTime / 10F;
+        }
+        return factor;
     }
 
     public ItemStack createItem() {

--- a/src/main/java/com/dre/brewery/configuration/files/Config.java
+++ b/src/main/java/com/dre/brewery/configuration/files/Config.java
@@ -165,6 +165,9 @@ public class Config extends AbstractOkaeriConfigFile {
     @LocalizedComment("config.agingYearDuration")
     private int agingYearDuration = 20;
 
+    @LocalizedComment("config.newBarrelTypeAlgorithm")
+    private boolean newBarrelTypeAlgorithm = false;
+
     @LocalizedComment("config.commandAliases")
     private List<String> commandAliases = List.of("brewery", "brew");
 

--- a/src/main/resources/config-langs/en.yml
+++ b/src/main/resources/config-langs/en.yml
@@ -60,6 +60,10 @@ config:
   requireKeywordOnSigns: "If barrels are only created when the sign placed contains the word \"barrel\" (or a translation when using another language) [true]"
   ageInMCBarrels: "If aging in -Minecraft- Barrels in enabled [true] and how many Brewery drinks can be put into them [6]"
   agingYearDuration: "Duration (in minutes) of a 'year' when aging drinks [20]"
+  newBarrelTypeAlgorithm: |
+    Whether to use the new algorithm for calculating wood type quality and shifting wood type when a brew is aged in different barrels.
+    False is the behavior of the original Brewery plugin.
+    True groups similar barrel types (such as oak and pale oak) together in a more intuitive way. [false]
   commandAliases: |
     Aliases for the '/breweryx' command. Requires a server restart to take effect. (list) [brewery, brew]
   enableEncode: |


### PR DESCRIPTION
I always thought how the plugin determines wood quality is weird and unintuitive, cherry wood is closer to copper and warped wood (2 indexes apart) than it is to oak wood (8 indexes apart). This PR aims to change that.

Wood types are organized into groups based on climate: Cold, Temperate, Hot Humid, Hot Dry, Nether, plus a separate group for Oak-based wood. The distance between the groups (0-3) determines the distance between two wood types (0-4, distance 1 is different wood types within the same group):
![barrel](https://github.com/user-attachments/assets/6106d1ff-942a-402d-b824-d25b3ddc8e42)

Copper is a special case. Copper has the same distance (3) to every other barrel type.

To calculate the barrel type quality for a recipe, [this formula](https://www.desmos.com/calculator/wbaoxucdsj) takes the distance between the two barrel types and recipe difficulty and outputs the brew quality.

When a brew already has a barrel type and is aged in a different barrel, the barrel type moves from one group to another, until the target group is reached, then one more step to get to the target barrel type. Since copper is a special case, it takes 2 steps to or from copper.

There are some limitations:
- Each group has a "primary" wood type that is shifted towards first.
- Wood shifting has the same problem as the old algorithm, aging the brew for a short time will not make any progress towards changing the barrel type, effectively wasting time.

I chose to implement barrel type distance this way because it does not require changing how brews are stored or breaking backwards compatibility. I do not recommend porting this algorithm to the Brewing Project because of the above limitations. Instead, qualities such as temperature, humidity, and "oak-ness" should be tracked separately, then the closest wood type would be chosen based on those three factors.

The new algorithm is disabled by default in case players are expecting the old behavior.