### PR TITLE
Allow recipes to have multiple barrel types

### DIFF
--- a/src/main/java/com/dre/brewery/BIngredients.java
+++ b/src/main/java/com/dre/brewery/BIngredients.java
@@ -438,7 +438,7 @@ public class BIngredients {
      * returns the quality regarding the barrel wood conditioning given Recipe
      */
     public int getWoodQuality(BRecipe recipe, BarrelWoodType wood) {
-        if (recipe.getWood().equals(BarrelWoodType.ANY)) {
+        if (recipe.usesAnyWood()) {
             // type of wood doesnt matter
             return 10;
         }

--- a/src/main/java/com/dre/brewery/BarrelWoodType.java
+++ b/src/main/java/com/dre/brewery/BarrelWoodType.java
@@ -27,6 +27,7 @@ import org.bukkit.Material;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.OptionalInt;
@@ -234,6 +235,16 @@ public enum BarrelWoodType {
         }
         return ANY;
     }
+
+    public static List<BarrelWoodType> listFromAny(Object intOrStringOrList) {
+        if (intOrStringOrList instanceof List<?> list) {
+            return list.stream()
+                .map(BarrelWoodType::fromAny)
+                .toList();
+        }
+        return Collections.singletonList(fromAny(intOrStringOrList));
+    }
+
 
     /**
      * Parses a string to determine the corresponding BarrelWoodType.

--- a/src/main/java/com/dre/brewery/configuration/sector/capsule/ConfigRecipe.java
+++ b/src/main/java/com/dre/brewery/configuration/sector/capsule/ConfigRecipe.java
@@ -49,7 +49,7 @@ public class ConfigRecipe extends OkaeriConfig {
     private Integer distillRuns;
     @CustomKey("distilltime")
     private Integer distillTime;
-    private Object wood; // int or String(Enum<BarrelWoodType>)
+    private Object wood; // int or String(Enum<BarrelWoodType>) or List<int or String(Enum<BarrelWoodType>)>
     private Integer age;
     private String color;
     private Integer difficulty;

--- a/src/main/resources/config-langs/en.yml
+++ b/src/main/resources/config-langs/en.yml
@@ -152,6 +152,7 @@ recipesFile:
     distilltime: How long (in seconds) one distill-run takes (0=Default time of 40 sec) MC Default would be 20 sec
 
     wood: Wood of the barrel:
+      Can be a string, a number (see conversion below), or a list of wood types.
       0=any 1=Birch 2=Oak 3=Jungle 4=Spruce
       5=Acacia 6=Dark Oak 7=Crimson 8=Warped
       9=Mangrove 10=Cherry 11=Bamboo 12=Cut Copper 13=Pale Oak

--- a/src/main/resources/languages/en.yml
+++ b/src/main/resources/languages/en.yml
@@ -13,7 +13,7 @@ Brew_MinutePluralPostfix: s
 Brew_OneYear: One Year
 Brew_ThickBrew: Muddy Brew
 Brew_Undefined: Cauldron Brew
-Brew_Woodtype: Woodtype
+Brew_Woodtype: Barrel Type
 Brew_Years: Years
 Brew_fermented: fermented
 Brew_minute: minute


### PR DESCRIPTION
The `wood` field now accepts a list of number or string wood types (old recipes still work). To determine a brew's quality, the brew's barrel type is compared to each of the recipe's expected barrel types, then the minimum distance is used. If the plugin has to choose a barrel type (such as with `/brew create`), the first is used.

Example:
```yaml
mead:
  name: Awkward Mead/Mead/&6Golden Mead
  ingredients:
  - Sugar_Cane/6
  cookingtime: 3
  distillruns: 0
  wood:
  - 2
  - Dark Oak
  - Pale Oak
  age: 4
  color: ORANGE
  difficulty: 2
  alcohol: 9
  lore:
  - +++ Has a golden shine
```

Also includes Pale Oak in recipe header and uses "barrel type" instead of "wood" since copper is not a type of wood.