### PR TITLE
Ruined brew hints

### DIFF
--- a/src/main/java/com/dre/brewery/BIngredients.java
+++ b/src/main/java/com/dre/brewery/BIngredients.java
@@ -28,10 +28,12 @@ import com.dre.brewery.lore.Base91EncoderStream;
 import com.dre.brewery.lore.BrewLore;
 import com.dre.brewery.recipe.BCauldronRecipe;
 import com.dre.brewery.recipe.BRecipe;
+import com.dre.brewery.recipe.BestRecipeResult;
 import com.dre.brewery.recipe.DebuggableItem;
 import com.dre.brewery.recipe.Ingredient;
 import com.dre.brewery.recipe.ItemLoader;
 import com.dre.brewery.recipe.PotionColor;
+import com.dre.brewery.recipe.RecipeEvaluation;
 import com.dre.brewery.recipe.RecipeItem;
 import com.dre.brewery.utility.BUtil;
 import com.dre.brewery.utility.Logging;
@@ -258,60 +260,108 @@ public class BIngredients {
     /**
      * best recipe for current state of potion, STILL not always returns the correct one...
      */
-    public BRecipe getBestRecipe(BarrelWoodType wood, float time, boolean distilled) {
-        float quality = 0;
-        int ingredientQuality;
-        int cookingQuality;
-        int woodQuality;
-        int ageQuality;
+    public @Nullable BRecipe getBestRecipe(BarrelWoodType wood, float time, boolean distilled) {
+        return getBestRecipeFull(wood, time, distilled).getSuccessRecipe();
+    }
+    /**
+     * best recipe for current state of potion, STILL not always returns the correct one...
+     */
+    public BestRecipeResult getBestRecipeFull(BarrelWoodType wood, float time, boolean distilled) {
+        if (BRecipe.getAllRecipes().isEmpty()) {
+            return new BestRecipeResult.NoRecipesRegistered();
+        }
+
+        // tracks the highest quality recipe using exact numbers, no rounding or clamping
+        // if no legacy recipe can be found, this is the plugin's best guess at what the player is trying to make
         BRecipe bestRecipe = null;
+        RecipeEvaluation bestEval = null;
+        // the original Brewery plugin uses a different algorithm that rounds and clamps ingredient/cook/age/wood
+        // qualities before adding them, so we have to do the same here to avoid breaking backward compatibility
+        float quality = 0;
+        BRecipe bestRecipeLegacy = null;
+        RecipeEvaluation bestEvalLegacy = null;
+
         // FIXME: This should include BCauldronRecipes too. (Proper parent class needed!)
         for (BRecipe recipe : BRecipe.getAllRecipes()) {
-            ingredientQuality = getIngredientQuality(recipe);
-            cookingQuality = getCookingQuality(recipe, distilled);
+            RecipeEvaluation completeRecipeEval;
 
-            if (ingredientQuality > -1 && cookingQuality > -1) {
-                if (recipe.needsToAge() || time > 0.5) {
-                    // needs riping in barrel
-                    ageQuality = getAgeQuality(recipe, time);
-                    woodQuality = getWoodQuality(recipe, wood);
-                    Logging.debugLog("Ingredient Quality: " + ingredientQuality + " Cooking Quality: " + cookingQuality +
-                        " Wood Quality: " + woodQuality + " age Quality: " + ageQuality + " for " + recipe.getName(5));
+            RecipeEvaluation ingredientEval = getIngredientQualityFull(recipe);
+            int ingredientQuality = ingredientEval.getQuality();
 
-                    // is this recipe better than the previous best?
-                    if ((((float) ingredientQuality + cookingQuality + woodQuality + ageQuality) / 4) > quality) {
-                        quality = ((float) ingredientQuality + cookingQuality + woodQuality + ageQuality) / 4;
-                        bestRecipe = recipe;
-                    }
-                } else {
-                    Logging.debugLog("Ingredient Quality: " + ingredientQuality + " Cooking Quality: " + cookingQuality + " for " + recipe.getName(5));
-                    // calculate quality without age and barrel
-                    if ((((float) ingredientQuality + cookingQuality) / 2) > quality) {
-                        quality = ((float) ingredientQuality + cookingQuality) / 2;
-                        bestRecipe = recipe;
-                    }
+            RecipeEvaluation cookingEval = getCookingQualityFull(recipe, distilled);
+            int cookingQuality = cookingEval.getQuality();
+
+            // age and wood quality cannot be fatal, only need to check ingredient and cooking
+            boolean isFatal = ingredientEval.hasFatalDefect() || cookingEval.hasFatalDefect();
+
+            if (recipe.needsToAge() || time > 0.5) {
+                // needs riping in barrel
+                RecipeEvaluation ageEval = getAgeQualityFull(recipe, time);
+                int ageQuality = ageEval.getQuality();
+
+                RecipeEvaluation woodEval = getWoodQualityFull(recipe, wood);
+                int woodQuality = woodEval.getQuality();
+
+                // is this recipe better than the previous best?
+                Logging.debugLog("Ingredient Quality: " + ingredientQuality + " Cooking Quality: " + cookingQuality +
+                    " Wood Quality: " + woodQuality + " age Quality: " + ageQuality + " for " + recipe.getName(5));
+                completeRecipeEval = RecipeEvaluation.combine(ingredientEval, cookingEval, ageEval, woodEval);
+
+                float averageQuality = ((float) ingredientQuality + cookingQuality + woodQuality + ageQuality) / 4;
+                if (!isFatal && averageQuality > quality) {
+                    quality = ((float) ingredientQuality + cookingQuality + woodQuality + ageQuality) / 4;
+                    bestRecipeLegacy = recipe;
+                    bestEvalLegacy = completeRecipeEval;
+                }
+
+            } else {
+                // calculate quality without age and barrel
+                Logging.debugLog("Ingredient Quality: " + ingredientQuality + " Cooking Quality: " + cookingQuality + " for " + recipe.getName(5));
+                completeRecipeEval = RecipeEvaluation.combine(ingredientEval, cookingEval);
+
+                float averageQuality = ((float) ingredientQuality + cookingQuality) / 2;
+                if (!isFatal && averageQuality > quality) {
+                    quality = averageQuality;
+                    bestRecipeLegacy = recipe;
+                    bestEvalLegacy = completeRecipeEval;
                 }
             }
+
+            if (bestEval == null || completeRecipeEval.compareMostToLeastComplexity(bestEval) > 0) {
+                bestRecipe = recipe;
+                bestEval = completeRecipeEval;
+            }
         }
-        if (bestRecipe != null) {
-            Logging.debugLog("best recipe: " + bestRecipe.getName(5) + " has Quality= " + quality);
+
+        if (bestRecipeLegacy != null) {
+            Logging.debugLog("best recipe: " + bestRecipeLegacy.getName(5) + " has Quality= " + quality);
+            return new BestRecipeResult.Found(bestRecipeLegacy, bestEvalLegacy);
+        } else {
+            // quality is guaranteed to be 0 or less, so constructor will never throw an exception
+            return new BestRecipeResult.Error(bestRecipe, bestEval);
         }
-        return bestRecipe;
     }
 
     /**
      * returns recipe that is cooking only and matches the ingredients and cooking time
      */
-    public BRecipe getCookRecipe() {
-        BRecipe bestRecipe = getBestRecipe(BarrelWoodType.ANY, 0, false);
+    public @Nullable BRecipe getCookRecipe() {
+        return getCookRecipeFull().getSuccessRecipe();
+    }
+    public BestRecipeResult getCookRecipeFull() {
+        BestRecipeResult result = getBestRecipeFull(BarrelWoodType.ANY, 0, false);
 
         // Check if best recipe is cooking only
-        if (bestRecipe != null) {
-            if (bestRecipe.isCookingOnly()) {
-                return bestRecipe;
+        if (result instanceof BestRecipeResult.Found found) {
+            if (found.recipe().isCookingOnly()) {
+                return result;
+            } else {
+                RecipeEvaluation eval = found.eval();
+                eval.fatal(new BrewDefect.CookTimeMismatch(cookedTime, 0));
+                return new BestRecipeResult.Error(found.recipe(), eval);
             }
         }
-        return null;
+        return result;
     }
 
     /**
@@ -338,92 +388,113 @@ public class BIngredients {
     /**
      * returns the currently best matching recipe for distilling for the ingredients and cooking time
      */
-    public BRecipe getDistillRecipe(BarrelWoodType wood, float time) {
-        BRecipe bestRecipe = getBestRecipe(wood, time, true);
+    public @Nullable BRecipe getDistillRecipe(BarrelWoodType wood, float time) {
+        return getDistillRecipeFull(wood, time).getSuccessRecipe();
+    }
+    public BestRecipeResult getDistillRecipeFull(BarrelWoodType wood, float time) {
+        BestRecipeResult result = getBestRecipeFull(wood, time, true);
 
-        // Check if best recipe needs to be destilled
-        if (bestRecipe != null) {
-            if (bestRecipe.needsDistilling()) {
-                return bestRecipe;
+        // Check if best recipe needs to be distilled
+        if (result instanceof BestRecipeResult.Found found) {
+            if (found.recipe().needsDistilling()) {
+                return result;
+            } else {
+                RecipeEvaluation eval = found.eval();
+                eval.fatal(new BrewDefect.DistillMismatch(true, false));
+                return new BestRecipeResult.Error(found.recipe(), eval);
             }
         }
-        return null;
+        return result;
     }
 
     /**
      * returns currently best matching recipe for ingredients, cooking- and ageingtime
      */
-    public BRecipe getAgeRecipe(BarrelWoodType wood, float time, boolean distilled) {
-        BRecipe bestRecipe = getBestRecipe(wood, time, distilled);
+    public @Nullable BRecipe getAgeRecipe(BarrelWoodType wood, float time, boolean distilled) {
+        return getAgeRecipeFull(wood, time, distilled).getSuccessRecipe();
+    }
+    public BestRecipeResult getAgeRecipeFull(BarrelWoodType wood, float time, boolean distilled) {
+        BestRecipeResult result = getBestRecipeFull(wood, time, distilled);
 
-        if (bestRecipe != null) {
-            if (bestRecipe.needsToAge()) {
-                return bestRecipe;
+        if (result instanceof BestRecipeResult.Found found) {
+            if (found.recipe().needsToAge()) {
+                return result;
+            } else {
+                RecipeEvaluation eval = found.eval();
+                eval.fatal(new BrewDefect.AgeMismatch(time, found.recipe().getAge()));
+                return new BestRecipeResult.Error(found.recipe(), eval);
             }
         }
-        return null;
+        return result;
     }
 
     /**
      * returns the quality of the ingredients conditioning given recipe, -1 if no recipe is near them
      */
     public int getIngredientQuality(BRecipe recipe) {
-        float quality = 10;
-        int count;
-        int badStuff = 0;
-        if (recipe.isMissingIngredients(ingredients)) {
+        return getIngredientQualityFull(recipe).getQuality();
+    }
+    public RecipeEvaluation getIngredientQualityFull(BRecipe recipe) {
+        RecipeEvaluation eval = new RecipeEvaluation();
+
+        List<RecipeItem> missingIngredients = recipe.getMissingIngredients(ingredients);
+        if (!missingIngredients.isEmpty()) {
             // when ingredients are not complete
-            return -1;
+            for (RecipeItem missing : missingIngredients) {
+                eval.fatal(new BrewDefect.MissingIngredient(missing, missing.getAmount()));
+            }
         }
+
+        int badStuff = 0;
         for (Ingredient ingredient : ingredients) {
             int amountInRecipe = recipe.amountOf(ingredient);
-            count = ingredient.getAmount();
+            int count = ingredient.getAmount();
             if (amountInRecipe == 0) {
-                // this ingredient doesnt belong into the recipe
-                if (count > (getIngredientsCount() / 2)) {
-                    // when more than half of the ingredients dont fit into the
-                    // recipe
-                    return -1;
-                }
+                // this ingredient doesn't belong into the recipe
                 badStuff++;
-                if (badStuff < ingredients.size()) {
+                if (count > (getIngredientsCount() / 2)) {
+                    // when more than half of the ingredients don't fit into the recipe
+                    eval.fatal(new BrewDefect.WrongIngredient(ingredient));
+                } else if (badStuff < ingredients.size()) {
                     // when there are other ingredients
-                    quality -= count * (recipe.getDifficulty() / 2.0);
-                    continue;
+                    float badIngredientDeduction = count * (recipe.getDifficulty() / 2.0f);
+                    eval.deduct(new BrewDefect.WrongIngredient(ingredient), badIngredientDeduction);
                 } else {
-                    // ingredients dont fit at all
-                    return -1;
+                    // ingredients don't fit at all
+                    eval.fatal(new BrewDefect.WrongIngredient(ingredient));
                 }
+            } else if (count != amountInRecipe) {
+                // calculate the quality
+                float ingredientCountDeduction = ((float) Math.abs(count - amountInRecipe) / recipe.allowedCountDiff(amountInRecipe)) * 10.0f;
+                eval.deduct(new BrewDefect.WrongCount(ingredient, amountInRecipe), ingredientCountDeduction);
             }
-            // calculate the quality
-            quality -= ((float) Math.abs(count - amountInRecipe) / recipe.allowedCountDiff(amountInRecipe)) * 10.0;
         }
-        if (quality >= 0) {
-            return Math.round(quality);
-        }
-        return -1;
+        return eval;
     }
 
     /**
      * returns the quality regarding the cooking-time conditioning given Recipe
      */
     public int getCookingQuality(BRecipe recipe, boolean distilled) {
-        if (!recipe.needsDistilling() == distilled) {
-            return -1;
+        return getCookingQualityFull(recipe, distilled).getQuality();
+    }
+    public RecipeEvaluation getCookingQualityFull(BRecipe recipe, boolean distilled) {
+        RecipeEvaluation eval = new RecipeEvaluation();
+        if (recipe.needsDistilling() != distilled) {
+            eval.fatal(new BrewDefect.DistillMismatch(distilled, recipe.needsDistilling()));
         }
-        int quality = 10 - (int) Math.round(((float) Math.abs(cookedTime - recipe.getCookingTime()) / recipe.allowedTimeDiff(recipe.getCookingTime())) * 10.0);
 
-        if (quality >= 0) {
-            if (cookedTime < 1) {
-                return 0;
-            }
-            return quality;
+        if (cookedTime < 1) {
+            eval.deduct(new BrewDefect.CookTimeMismatch(0, recipe.getCookingTime()), 10);
+        } else if (cookedTime != recipe.getCookingTime()) {
+            float cookTimeDeduction = ((float) Math.abs(cookedTime - recipe.getCookingTime()) / recipe.allowedTimeDiff(recipe.getCookingTime())) * 10.0f;
+            eval.deduct(new BrewDefect.CookTimeMismatch(cookedTime, recipe.getCookingTime()), cookTimeDeduction);
         }
-        return -1;
+        return eval;
     }
 
     /**
-     * returns pseudo quality of distilling. 0 if doesnt match the need of the recipes distilling
+     * returns pseudo quality of distilling. 0 if doesn't match the need of the recipes distilling
      */
     public int getDistillQuality(BRecipe recipe, byte distillRuns) {
         if (recipe.needsDistilling() != distillRuns > 0) {
@@ -436,22 +507,34 @@ public class BIngredients {
      * returns the quality regarding the barrel wood conditioning given Recipe
      */
     public int getWoodQuality(BRecipe recipe, BarrelWoodType wood) {
+        return getWoodQualityFull(recipe, wood).getQuality();
+    }
+    public RecipeEvaluation getWoodQualityFull(BRecipe recipe, BarrelWoodType wood) {
+        RecipeEvaluation eval = new RecipeEvaluation();
         if (recipe.getWood().equals(BarrelWoodType.ANY)) {
             // type of wood doesnt matter
-            return 10;
+            return eval;
         }
-        int quality = 10 - Math.round(recipe.getWoodDiff(wood.getIndex()) * recipe.getDifficulty());
-
-        return Math.max(quality, 0);
+        if (wood != recipe.getWood()) {
+            float woodDeduction = recipe.getWoodDiff(wood.getIndex()) * recipe.getDifficulty();
+            eval.deduct(new BrewDefect.WrongWood(wood, recipe.getWood()), woodDeduction);
+        }
+        return eval;
     }
 
     /**
      * returns the quality regarding the ageing time conditioning given Recipe
      */
     public int getAgeQuality(BRecipe recipe, float time) {
-        int quality = 10 - Math.round(Math.abs(time - recipe.getAge()) * ((float) recipe.getDifficulty() / 2));
-
-        return Math.max(quality, 0);
+        return getAgeQualityFull(recipe, time).getQuality();
+    }
+    public RecipeEvaluation getAgeQualityFull(BRecipe recipe, float time) {
+        RecipeEvaluation eval = new RecipeEvaluation();
+        if (!BUtil.isClose(time, recipe.getAge())) {
+            float ageDeduction = Math.abs(time - recipe.getAge()) * ((float) recipe.getDifficulty() / 2);
+            eval.deduct(new BrewDefect.AgeMismatch(time, recipe.getAge()), ageDeduction);
+        }
+        return eval;
     }
 
     @Override

--- a/src/main/java/com/dre/brewery/Brew.java
+++ b/src/main/java/com/dre/brewery/Brew.java
@@ -35,6 +35,7 @@ import com.dre.brewery.lore.XORScrambleStream;
 import com.dre.brewery.lore.XORUnscrambleStream;
 import com.dre.brewery.recipe.BEffect;
 import com.dre.brewery.recipe.BRecipe;
+import com.dre.brewery.recipe.BestRecipeResult;
 import com.dre.brewery.recipe.PotionColor;
 import com.dre.brewery.utility.BUtil;
 import com.dre.brewery.utility.Logging;
@@ -623,19 +624,25 @@ public class Brew implements Cloneable {
 
         distillRuns += 1;
         BrewLore lore = new BrewLore(this, potionMeta);
-        BRecipe recipe = ingredients.getDistillRecipe(wood, ageTime);
-        if (recipe != null) {
+        BestRecipeResult result = ingredients.getDistillRecipeFull(wood, ageTime);
+        if (result instanceof BestRecipeResult.Found found) {
             // distillRuns will have an effect on the amount of alcohol, not the quality
-            currentRecipe = recipe;
+            currentRecipe = found.recipe();
             quality = calcQuality();
 
             lore.addOrReplaceEffects(getEffects(), quality);
-            potionMeta.setDisplayName(BUtil.color("&f" + recipe.getName(quality)));
-            recipe.getColor().colorBrew(potionMeta, slotItem, canDistill());
+            potionMeta.setDisplayName(BUtil.color("&f" + currentRecipe.getName(quality)));
+            currentRecipe.getColor().colorBrew(potionMeta, slotItem, canDistill());
 
         } else {
             quality = 0;
             lore.removeEffects();
+            Logging.debugLog("Distill brew ruined! " + result);
+            if (config.isShowRuinedBrewHints()) {
+                BrewDefect defect = result.getWorstDefect();
+                assert defect != null; // since no recipe was found, there must be a defect
+                lore.updateDefect(BUtil.choose(defect.getMessages(lang)));
+            }
             potionMeta.setDisplayName(BUtil.color("&f" + lang.getEntry("Brew_DistillUndefined")));
             PotionColor.GREY.colorBrew(potionMeta, slotItem, canDistill());
         }
@@ -697,16 +704,16 @@ public class Brew implements Cloneable {
             } else if (wood != woodType) {
                 woodShift(time, woodType);
             }
-            BRecipe recipe = ingredients.getAgeRecipe(wood, ageTime, distillRuns > 0);
-            if (recipe != null) {
-                currentRecipe = recipe;
+            BestRecipeResult result = ingredients.getAgeRecipeFull(wood, ageTime, distillRuns > 0);
+            if (result instanceof BestRecipeResult.Found found) {
+                currentRecipe = found.recipe();
                 quality = calcQuality();
 
                 lore.addOrReplaceEffects(getEffects(), quality);
-                potionMeta.setDisplayName(BUtil.color("&f" + recipe.getName(quality)));
-                recipe.getColor().colorBrew(potionMeta, item, canDistill());
+                potionMeta.setDisplayName(BUtil.color("&f" + currentRecipe.getName(quality)));
+                currentRecipe.getColor().colorBrew(potionMeta, item, canDistill());
 
-                if (recipe.isGlint()) {
+                if (currentRecipe.isGlint()) {
                     potionMeta.addEnchant(Enchantment.MENDING, 1, true);
                     potionMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
                 }
@@ -714,6 +721,12 @@ public class Brew implements Cloneable {
                 quality = 0;
                 lore.convertLore(false);
                 lore.removeEffects();
+                Logging.debugLog("Aging brew ruined! " + result);
+                if (config.isShowRuinedBrewHints()) {
+                    BrewDefect defect = result.getWorstDefect();
+                    assert defect != null; // since no recipe was found, there must be a defect
+                    lore.updateDefect(BUtil.choose(defect.getMessages(lang)));
+                }
                 currentRecipe = null;
                 potionMeta.setDisplayName(BUtil.color("&f" + lang.getEntry("Brew_BadPotion")));
                 PotionColor.GREY.colorBrew(potionMeta, item, canDistill());

--- a/src/main/java/com/dre/brewery/BrewDefect.java
+++ b/src/main/java/com/dre/brewery/BrewDefect.java
@@ -1,0 +1,182 @@
+/*
+ * BreweryX Bukkit-Plugin for an alternate brewing process
+ * Copyright (C) 2025 The Brewery Team
+ *
+ * This file is part of BreweryX.
+ *
+ * BreweryX is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BreweryX is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BreweryX. If not, see <http://www.gnu.org/licenses/gpl-3.0.html>.
+ */
+
+package com.dre.brewery;
+
+import com.dre.brewery.configuration.files.Lang;
+import com.dre.brewery.recipe.DebuggableItem;
+import com.dre.brewery.recipe.Ingredient;
+import com.dre.brewery.utility.BUtil;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Represents an imperfection with a brew given the recipe the player is attempting to make.
+ */
+public interface BrewDefect {
+
+    List<String> getMessages(Lang lang);
+
+    record WrongIngredient(DebuggableItem ingredient) implements BrewDefect {
+        @Override
+        public List<String> getMessages(Lang lang) {
+            return lang.getEntries("Defect_WrongIngredient");
+        }
+
+        @Override
+        public String toString() {
+            return String.format("WrongIngredient{%s}", ingredient.getDebugID());
+        }
+    }
+
+    record MissingIngredient(DebuggableItem ingredient, int amountNeeded) implements BrewDefect {
+        @Override
+        public List<String> getMessages(Lang lang) {
+            return lang.getEntries("Defect_MissingIngredient");
+        }
+
+        @Override
+        public String toString() {
+            return String.format("MissingIngredient{%dx %s}", amountNeeded, ingredient.getDebugID());
+        }
+    }
+
+    record WrongCount(Ingredient ingredient, int amountNeeded) implements BrewDefect {
+        public WrongCount {
+            if (ingredient.getAmount() == amountNeeded) {
+                throw new IllegalArgumentException("WrongCount actual and needed counts were equal");
+            }
+        }
+
+        @Override
+        public List<String> getMessages(Lang lang) {
+            if (ingredient.getAmount() < amountNeeded) {
+                return lang.getEntries("Defect_LowCount");
+            } else {
+                return lang.getEntries("Defect_HighCount");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return String.format("WrongCount{%d/%d %s}", ingredient.getAmount(), amountNeeded, ingredient.getDebugID());
+        }
+    }
+
+    record DistillMismatch(boolean actual, boolean needed) implements BrewDefect {
+        public DistillMismatch {
+            if (actual == needed) {
+                throw new IllegalArgumentException("DistillMismatch actual and needed were equal");
+            }
+        }
+
+        @Override
+        public List<String> getMessages(Lang lang) {
+            if (needed) {
+                return lang.getEntries("Defect_NeedsDistill");
+            } else {
+                return lang.getEntries("Defect_BadDistill");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return needed ? "DistillNeeded" : "DistillUnnecessary";
+        }
+    }
+
+    record CookTimeMismatch(int actual, int needed) implements BrewDefect {
+        public CookTimeMismatch {
+            if (actual == needed) {
+                throw new IllegalArgumentException("CookTimeMismatch actual and needed were equal");
+            }
+        }
+
+        @Override
+        public List<String> getMessages(Lang lang) {
+            if (actual < needed) {
+                return lang.getEntries("Defect_Uncooked");
+            } else {
+                return lang.getEntries("Defect_Overcooked");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return String.format("CookTimeMismatch{%d/%d}", actual, needed);
+        }
+    }
+
+    record AgeMismatch(float actual, float needed) implements BrewDefect {
+        public AgeMismatch {
+            if (BUtil.isClose(actual, needed)) {
+                throw new IllegalArgumentException("AgeMismatch actual and needed were equal");
+            }
+        }
+
+        @Override
+        public List<String> getMessages(Lang lang) {
+            if (needed == 0.0f) {
+                return lang.getEntries("Defect_BadAged");
+            } else if (actual < needed) {
+                return lang.getEntries("Defect_UnderAged");
+            } else {
+                return lang.getEntries("Defect_OverAged");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return String.format("AgeMismatch{%.3f/%.3f}", actual, needed);
+        }
+    }
+
+    record WrongWood(BarrelWoodType actual, BarrelWoodType needed) implements BrewDefect {
+        public WrongWood {
+            if (actual == needed) {
+                throw new IllegalArgumentException("WrongWood actual and needed were equal");
+            }
+        }
+
+        @Override
+        public List<String> getMessages(Lang lang) {
+            return lang.getEntries("Defect_WrongWood", actual.getFormattedName().toLowerCase(Locale.ROOT));
+        }
+
+        @Override
+        public String toString() {
+            return String.format("WrongWood{was %s, needs %s}", actual.getFormattedName(), needed.getFormattedName());
+        }
+    }
+
+    record NoRecipesRegistered() implements BrewDefect {
+        @Override
+        public List<String> getMessages(Lang lang) {
+            return lang.getEntries("Defect_NoRecipesRegistered");
+        }
+
+        @Override
+        public String toString() {
+            return "NoRecipesRegistered{}";
+        }
+    }
+
+}

--- a/src/main/java/com/dre/brewery/configuration/files/Config.java
+++ b/src/main/java/com/dre/brewery/configuration/files/Config.java
@@ -152,6 +152,9 @@ public class Config extends AbstractOkaeriConfigFile {
     @LocalizedComment("config.alwaysShowAlcIndicator")
     private boolean alwaysShowAlcIndicator = true;
 
+    @LocalizedComment("config.showRuinedBrewHints")
+    private boolean showRuinedBrewHints = false;
+
     @LocalizedComment("config.showBrewer")
     private boolean showBrewer = false;
 

--- a/src/main/java/com/dre/brewery/configuration/files/Lang.java
+++ b/src/main/java/com/dre/brewery/configuration/files/Lang.java
@@ -39,12 +39,13 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 // Our bind file for this class should vary based on what language the user has set in the config.
 @OkaeriConfigFileOptions(useLangFileName = true, removeOrphans = true)
-@Header({ "!!! IMPORTANT: BreweryX configuration files do NOT support external comments! If you add any comments, they will be overwritten !!!",
-    "Translations for BreweryX" })
+@Header({"!!! IMPORTANT: BreweryX configuration files do NOT support external comments! If you add any comments, they will be overwritten !!!",
+    "Translations for BreweryX"})
 @DefaultCommentSpace(1)
 @SuppressWarnings("unused")
 public class Lang extends AbstractOkaeriConfigFile {
@@ -52,7 +53,7 @@ public class Lang extends AbstractOkaeriConfigFile {
     @Exclude
     private transient final Config config = ConfigManager.getConfig(Config.class);
     @Exclude
-    private transient Map<String, String> mappedEntries;
+    private transient Map<String, Object> mappedEntries; // String or List<String> only
 
     @SneakyThrows
     @Override // Should override because we need to remap our strings after a reload of this file.
@@ -77,13 +78,13 @@ public class Lang extends AbstractOkaeriConfigFile {
         }
 
         for (Field field : this.getClass().getDeclaredFields()) {
-            if (field.getType() != String.class) {
+            if (field.getType() != String.class && field.getType() != List.class) {
                 continue;
             }
 
             try {
-                String thisValue = (String) field.get(this);
-                String otherValue = (String) field.get(other);
+                Object thisValue = field.get(this);
+                Object otherValue = field.get(other);
                 if (thisValue == null && otherValue != null) {
                     field.set(this, otherValue);
                 }
@@ -99,16 +100,16 @@ public class Lang extends AbstractOkaeriConfigFile {
 
         this.mappedEntries = new HashMap<>();
         for (Field field : this.getClass().getDeclaredFields()) {
-            if (field.getType() != String.class) {
+            if (field.getType() != String.class && field.getType() != List.class) {
                 continue;
             }
 
             try {
                 CustomKey customKey = field.getAnnotation(CustomKey.class);
                 if (customKey != null) {
-                    this.mappedEntries.put(customKey.value(), (String) field.get(this));
+                    this.mappedEntries.put(customKey.value(), field.get(this));
                 } else {
-                    this.mappedEntries.put(field.getName(), (String) field.get(this));
+                    this.mappedEntries.put(field.getName(), field.get(this));
                 }
             } catch (IllegalAccessException e) {
                 Logging.errorLog("Lang failed to get a field value! &6(" + field.getName() + ")", e);
@@ -132,21 +133,53 @@ public class Lang extends AbstractOkaeriConfigFile {
         if (mappedEntries == null) {
             mapStrings();
         }
-        String entry = mappedEntries.get(key);
 
-        if (entry != null) {
-            int i = 0;
-            for (Object arg : args) {
-                if (arg != null) {
-                    i++;
-                    entry = entry.replace("&v" + i, arg.toString());
-                }
-            }
+        String msg;
+        Object entry = mappedEntries.get(key);
+        if (entry instanceof String) {
+            msg = format((String) entry, args);
+        } else if (entry instanceof List) {
+            msg = "&c[LanguageReader] Config entry for key '" + key + "' is a list!";
         } else {
-            entry = "&c[LanguageReader] Failed to retrieve a config entry for key '" + key + "'!";
+            msg = "&c[LanguageReader] Failed to retrieve a config entry for key '" + key + "'!";
+        }
+        return color ? BUtil.color(msg) : msg;
+    }
+
+    public List<String> getEntries(String key, Object... args) {
+        return this.getEntries(key, true, args);
+    }
+
+    @SuppressWarnings("unchecked") // All lists in this class are List<String>
+    public List<String> getEntries(String key, boolean color, Object... args) {
+        if (mappedEntries == null) {
+            mapStrings();
         }
 
-        return color ? BUtil.color(entry) : entry;
+        List<String> msgs;
+        Object entry = mappedEntries.get(key);
+        if (entry instanceof String) {
+            msgs = List.of((String) entry);
+        } else if (entry instanceof List) {
+            msgs = (List<String>) entry;
+        } else {
+            msgs = List.of("&c[LanguageReader] Failed to retrieve a config entry for key '" + key + "'!");
+        }
+        return msgs.stream()
+            .map(s -> format(s, args))
+            .map(s -> color ? BUtil.color(s) : s)
+            .toList();
+    }
+
+    private static String format(String entry, Object... args) {
+        int i = 0;
+        for (Object arg : args) {
+            if (arg != null) {
+                i++;
+                entry = entry.replace("&v" + i, arg.toString());
+            }
+        }
+        return entry;
     }
 
 
@@ -252,6 +285,35 @@ public class Lang extends AbstractOkaeriConfigFile {
     private String cmdDistillRuined;
     @CustomKey("CMD_Age_Ruined")
     private String cmdAgeRuined;
+
+
+    @Comment("Brew Defects")
+    @CustomKey("Defect_WrongIngredient")
+    private List<String> defectWrongIngredient;
+    @CustomKey("Defect_MissingIngredient")
+    private List<String> defectMissingIngredient;
+    @CustomKey("Defect_LowCount")
+    private List<String> defectLowCount;
+    @CustomKey("Defect_HighCount")
+    private List<String> defectHighCount;
+    @CustomKey("Defect_NeedsDistill")
+    private List<String> defectNeedsDistill;
+    @CustomKey("Defect_BadDistill")
+    private List<String> defectBadDistill;
+    @CustomKey("Defect_Uncooked")
+    private List<String> defectUncooked;
+    @CustomKey("Defect_Overcooked")
+    private List<String> defectOvercooked;
+    @CustomKey("Defect_UnderAged")
+    private List<String> defectUnderAged;
+    @CustomKey("Defect_OverAged")
+    private List<String> defectOverAged;
+    @CustomKey("Defect_BadAged")
+    private List<String> defectBadAged;
+    @CustomKey("Defect_WrongWood")
+    private List<String> defectWrongWood;
+    @CustomKey("Defect_NoRecipesRegistered")
+    private List<String> defectNoRecipesRegistered;
 
 
     @Comment("Error")

--- a/src/main/java/com/dre/brewery/lore/BrewLore.java
+++ b/src/main/java/com/dre/brewery/lore/BrewLore.java
@@ -306,6 +306,16 @@ public class BrewLore {
         }
     }
 
+    public void updateDefect(@Nullable String defectMessage) {
+        if (defectMessage != null) {
+            if (Type.DEFECT.findInLore(lore) == -1) {
+                addOrReplaceLore(Type.DEFECT, "§c", defectMessage);
+            }
+        } else {
+            removeLore(Type.DEFECT);
+        }
+    }
+
     public void updateBrewer(String name) {
         if (name != null && config.isShowBrewer()) {
             addOrReplaceLore(Type.BREWER, "§8", lang.getEntry("Brew_Brewer", name));
@@ -603,7 +613,9 @@ public class BrewLore {
         AGE("§y"),
         WOOD("§z"),
         ALC("§q"),
+        DEFECT("§i"),
         BREWER("§g");
+        // Available: j, non-letters (server deletes §x)
 
         public final String id;
 

--- a/src/main/java/com/dre/brewery/recipe/BRecipe.java
+++ b/src/main/java/com/dre/brewery/recipe/BRecipe.java
@@ -475,6 +475,22 @@ public class BRecipe implements Cloneable {
         }
         return false;
     }
+    public List<RecipeItem> getMissingIngredients(List<Ingredient> list) {
+        List<RecipeItem> missing = new ArrayList<>();
+        for (RecipeItem rItem : ingredients) {
+            boolean matches = false;
+            for (Ingredient used : list) {
+                if (rItem.matches(used)) {
+                    matches = true;
+                    break;
+                }
+            }
+            if (!matches) {
+                missing.add(rItem);
+            }
+        }
+        return missing;
+    }
 
     public void applyDrinkFeatures(Player player, int quality) {
         List<String> playerCmdsForQuality = getPlayercmdsForQuality(quality);

--- a/src/main/java/com/dre/brewery/recipe/BestRecipeResult.java
+++ b/src/main/java/com/dre/brewery/recipe/BestRecipeResult.java
@@ -1,0 +1,133 @@
+/*
+ * BreweryX Bukkit-Plugin for an alternate brewing process
+ * Copyright (C) 2024-2025 The Brewery Team
+ *
+ * This file is part of BreweryX.
+ *
+ * BreweryX is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BreweryX is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BreweryX. If not, see <http://www.gnu.org/licenses/gpl-3.0.html>.
+ */
+
+package com.dre.brewery.recipe;
+
+import com.dre.brewery.BrewDefect;
+import com.dre.brewery.utility.BUtil;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.StringJoiner;
+
+/**
+ * The set of possible results from trying to find the best recipe given some ingredients.
+ */
+public sealed interface BestRecipeResult {
+
+    /**
+     * Gets the best recipe, if one with quality above 0 was found.
+     * @return the recipe, or null if not found
+     */
+    @Nullable BRecipe getSuccessRecipe();
+
+    /**
+     * If no recipe was found, gets the worst defect of the next best recipe.
+     * If there are multiple equally bad defects, one is chosen at random.
+     * @return the worst defect, or null if a recipe was found
+     */
+    @Nullable BrewDefect getWorstDefect();
+
+    /**
+     * A recipe matching the ingredients was found.
+     * @param recipe the best recipe with the highest quality
+     * @param eval the recipe's evaluation
+     */
+    record Found(BRecipe recipe, RecipeEvaluation eval) implements BestRecipeResult {
+
+        @Override
+        public @Nullable BRecipe getSuccessRecipe() {
+            return recipe;
+        }
+
+        @Override
+        public @Nullable BrewDefect getWorstDefect() {
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return new StringJoiner(", ", "Found{", "}")
+                .add("recipe=" + recipe)
+                .add("eval=" + eval)
+                .toString();
+        }
+
+    }
+
+    /**
+     * No recipe with quality above 0 was found.
+     * @param guess the failed recipe with the highest quality (or least problems),
+     *              a "best guess" of what the user was trying to brew
+     * @param eval the recipe's evaluation
+     */
+    record Error(BRecipe guess, RecipeEvaluation eval) implements BestRecipeResult {
+
+        /**
+         * @throws IllegalArgumentException if quality is greater than 0
+         */
+        public Error {
+            if (eval.isUsable()) {
+                throw new IllegalArgumentException("quality must be 0 or lower to error!");
+            }
+        }
+
+        @Override
+        public @Nullable BRecipe getSuccessRecipe() {
+            return null;
+        }
+
+        @Override
+        public @Nullable BrewDefect getWorstDefect() {
+            return BUtil.choose(eval.getWorstDefects());
+        }
+
+        @Override
+        public String toString() {
+            return new StringJoiner(", ", "Error{", "}")
+                .add("guess=" + guess)
+                .add("eval=" + eval)
+                .toString();
+        }
+
+    }
+
+    /**
+     * Somehow, no recipes are loaded.
+     */
+    record NoRecipesRegistered() implements BestRecipeResult {
+
+        @Override
+        public @Nullable BRecipe getSuccessRecipe() {
+            return null;
+        }
+
+        @Override
+        public BrewDefect getWorstDefect() {
+            return new BrewDefect.NoRecipesRegistered();
+        }
+
+        @Override
+        public String toString() {
+            return "NoRecipesAvailable{}";
+        }
+
+    }
+
+}

--- a/src/main/java/com/dre/brewery/recipe/QualityDeduction.java
+++ b/src/main/java/com/dre/brewery/recipe/QualityDeduction.java
@@ -1,0 +1,99 @@
+/*
+ * BreweryX Bukkit-Plugin for an alternate brewing process
+ * Copyright (C) 2024-2025 The Brewery Team
+ *
+ * This file is part of BreweryX.
+ *
+ * BreweryX is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BreweryX is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BreweryX. If not, see <http://www.gnu.org/licenses/gpl-3.0.html>.
+ */
+
+package com.dre.brewery.recipe;
+
+import com.dre.brewery.BrewDefect;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Represents a deduction of quality caused by a {@link BrewDefect}.
+ * Sort order is <strong>only</strong> determined by quality. Two QualityDeductions with the same quality but
+ * different defects will be considered the same for sorting.
+ */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class QualityDeduction implements Comparable<QualityDeduction> {
+
+    /** The reason for this deduction */
+    private final BrewDefect defect;
+    /** The amount to deduct by, will be negative infinity if fatal */
+    private final float qualityDeduction;
+
+    /**
+     * Creates a quality deduction with the given amount.
+     * @param defect the defect that is the reason for this deduction
+     * @param qualityDeduction the amount to deduct
+     * @return the quality deduction
+     * @throws IllegalArgumentException if qualityDeduction is not finite
+     */
+    public static QualityDeduction deduction(BrewDefect defect, float qualityDeduction) {
+        if (!Float.isFinite(qualityDeduction)) {
+            throw new IllegalArgumentException("qualityDeduction must be finite");
+        }
+        return new QualityDeduction(defect, qualityDeduction);
+    }
+
+    /**
+     * Creates a fatal quality deduction, which prevents the brew from being used.
+     * @param defect the defect that is the reason for this deduction
+     * @return the quality deduction
+     */
+    public static QualityDeduction fatal(BrewDefect defect) {
+        return new QualityDeduction(defect, Float.NEGATIVE_INFINITY);
+    }
+
+    /**
+     * @return whether this defect is fatal, and should prevent the brew from being used
+     */
+    public boolean isFatal() {
+        return qualityDeduction == Float.NEGATIVE_INFINITY;
+    }
+
+    /**
+     * Scales the deduction amount by the given factor.
+     * @param f the factor to scale by
+     * @return the scaled quality deduction
+     * @throws IllegalArgumentException if f is negative
+     */
+    public QualityDeduction scale(float f) {
+        if (f < 0) {
+            throw new IllegalArgumentException("f must be positive");
+        }
+        // ok since -inf * anything non-negative = -inf
+        return new QualityDeduction(defect, qualityDeduction * f);
+    }
+
+    @Override
+    public int compareTo(QualityDeduction other) {
+        return Float.compare(qualityDeduction, other.qualityDeduction);
+    }
+
+    @Override
+    public String toString() {
+        if (isFatal()) {
+            return "FATAL " + defect;
+        }
+        return String.format("-%.3f %s", qualityDeduction, defect);
+    }
+
+}

--- a/src/main/java/com/dre/brewery/recipe/RecipeEvaluation.java
+++ b/src/main/java/com/dre/brewery/recipe/RecipeEvaluation.java
@@ -1,0 +1,197 @@
+/*
+ * BreweryX Bukkit-Plugin for an alternate brewing process
+ * Copyright (C) 2024-2025 The Brewery Team
+ *
+ * This file is part of BreweryX.
+ *
+ * BreweryX is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BreweryX is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BreweryX. If not, see <http://www.gnu.org/licenses/gpl-3.0.html>.
+ */
+
+package com.dre.brewery.recipe;
+
+import com.dre.brewery.BrewDefect;
+import com.dre.brewery.utility.BUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+/**
+ * Helper class that keeps track of {@link BrewDefect BrewDefects} and their quality deductions.
+ * Quality starts at 10, and is reduced by each defect.
+ */
+public class RecipeEvaluation {
+
+    private final List<QualityDeduction> deductions = new ArrayList<>();
+
+    /**
+     * Deducts quality by the specified amount.
+     * @param defect the defect that caused the quality deduction
+     * @param qualityDeduction the amount to deduct by
+     * @throws IllegalArgumentException if qualityDeduction is negative
+     */
+    public void deduct(BrewDefect defect, float qualityDeduction) {
+        if (qualityDeduction < 0) {
+            throw new IllegalArgumentException("qualityDeduction cannot be negative");
+        }
+        deductions.add(QualityDeduction.deduction(defect, qualityDeduction));
+    }
+
+    /**
+     * Adds a fatal defect that prevents the recipe from being used.
+     * @param defect the defect
+     */
+    public void fatal(BrewDefect defect) {
+        deductions.add(QualityDeduction.fatal(defect));
+    }
+
+    /**
+     * Combines multiple RecipeEvaluations into one.
+     * If there are {@code n} evaluations, each evaluation contributes {@code 1/n} of the quality.
+     * @param evals the evaluations
+     * @return the combined evaluation
+     */
+    public static RecipeEvaluation combine(RecipeEvaluation... evals) {
+        RecipeEvaluation combined = new RecipeEvaluation();
+        for (RecipeEvaluation eval : evals) {
+            List<QualityDeduction> scaledDown = eval.deductions.stream()
+                .map(d -> d.scale(1.0f / evals.length))
+                .toList();
+            combined.deductions.addAll(scaledDown);
+        }
+        return combined;
+    }
+
+    /**
+     * @return whether {@link #getQuality()} is greater than 0
+     */
+    public boolean isUsable() {
+        return getQuality() > 0;
+    }
+
+    /**
+     * @return whether there are any fatal defects
+     */
+    public boolean hasFatalDefect() {
+        return deductions.stream().anyMatch(QualityDeduction::isFatal);
+    }
+
+    /**
+     * Gets the quality of the recipe. Will be between 0 and 10 inclusive and rounded.
+     * If there are fatal defects, or if the quality is deducted to less than 0,the quality will be -1.
+     * @return the quality
+     */
+    public int getQuality() {
+        float quality = getTrueQuality();
+        if (quality < 0) {
+            return -1;
+        }
+        return Math.round(quality);
+    }
+
+    /**
+     * Gets the true quality of the recipe, without rounding or bounds.
+     * Can be any number 10 or below. Will be negative infinity if there are fatal defects.
+     * @return the true quality
+     */
+    public float getTrueQuality() {
+        if (hasFatalDefect()) {
+            return Float.NEGATIVE_INFINITY;
+        }
+        return deductions.stream()
+            .map(QualityDeduction::getQualityDeduction)
+            .reduce(10f, (q1, q2) -> q1 - q2);
+    }
+
+    /**
+     * @return all quality deductions, in arbitrary order
+     */
+    public List<QualityDeduction> getDeductions() {
+        return Collections.unmodifiableList(deductions);
+    }
+
+    /**
+     * Gets the defect that deducts the most quality from the recipe.
+     * If there is a tie, multiple defects are returned.
+     * @return list of defects, possibly empty
+     */
+    public List<BrewDefect> getWorstDefects() {
+        if (hasFatalDefect()) {
+            return deductions.stream()
+                .filter(QualityDeduction::isFatal)
+                .map(QualityDeduction::getDefect)
+                .toList();
+        } else {
+            return BUtil.multiMin(deductions).stream()
+                .map(QualityDeduction::getDefect)
+                .toList();
+        }
+    }
+
+    /**
+     * Compares two RecipeEvaluations, in order of most complexity to least complexity.
+     * Recipe evaluations are sorted by, in order:
+     * <ul>
+     *     <li>Number of total defects, most to fewest</li>
+     *     <li>Number of fatal defects, most to fewest</li>
+     *     <li>{@link #getTrueQuality()}, lowest to highest</li>
+     * </ul>
+     * @param other the other evaluation
+     * @return -1, 0, or 1 if <, =, or >
+     * @throws NullPointerException if other is null
+     */
+    public int compareMostToLeastComplexity(RecipeEvaluation other) {
+        if (other == null) {
+            throw new NullPointerException("other cannot be null");
+        }
+        int numDefectsCompare = -Integer.compare(deductions.size(), other.deductions.size());
+        if (numDefectsCompare != 0) {
+            return numDefectsCompare;
+        }
+        int thisFatalCount = fatalCount();
+        boolean thisFatal = thisFatalCount > 0;
+        int otherFatalCount = other.fatalCount();
+        boolean otherFatal = otherFatalCount > 0;
+        if (!thisFatal && !otherFatal) {
+            return Float.compare(getTrueQuality(), other.getTrueQuality());
+        }
+        if (thisFatal && otherFatal) {
+            return -Integer.compare(thisFatalCount, otherFatalCount);
+        }
+        return -Boolean.compare(thisFatal, otherFatal);
+    }
+    private int fatalCount() {
+        return (int) deductions.stream()
+            .filter(QualityDeduction::isFatal)
+            .count();
+    }
+
+    @Override
+    public String toString() {
+        float quality = getTrueQuality();
+        String qualityStr = quality == Float.NEGATIVE_INFINITY ? "fatal" : String.format("%.3f", quality);
+
+        String deductionsStr = deductions.stream()
+            .map(QualityDeduction::toString)
+            .collect(Collectors.joining(", ", "[", "]"));
+
+        return new StringJoiner(", ", "{", "}")
+            .add("quality=" + qualityStr)
+            .add("deductions=" + deductionsStr)
+            .toString();
+    }
+
+}

--- a/src/main/java/com/dre/brewery/utility/BUtil.java
+++ b/src/main/java/com/dre/brewery/utility/BUtil.java
@@ -46,6 +46,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
@@ -54,6 +55,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
@@ -543,6 +545,57 @@ public final class BUtil {
         }
 
         return 0;
+    }
+
+    /**
+     * Chooses a random element from a list.
+     * @param list the list to choose from
+     * @return a random element, or null if the list is empty
+     * @param <T> type of element in list
+     */
+    public static <T> @Nullable T choose(List<T> list) {
+        if (list.isEmpty()) {
+            return null;
+        }
+        return list.get(ThreadLocalRandom.current().nextInt(list.size()));
+    }
+
+    /**
+     * Finds the minimum element in a collection.
+     * If multiple elements have the same minimum value, they will all be returned.
+     * @param <T> the type of elements in the collection
+     * @param collection the collection to search for minimum elements
+     * @return a list of all minimum elements in the collection, will be empty if the collection is empty
+     */
+    public static <T extends Comparable<T>> List<T> multiMin(Collection<T> collection) {
+        List<T> minValues = new ArrayList<>();
+        T min = null;
+        for (T t : collection) {
+            if (min == null) {
+                min = t;
+                minValues.add(t);
+            } else {
+                int compare = t.compareTo(min);
+                if (compare < 0) {
+                    min = t;
+                    minValues.clear();
+                    minValues.add(t);
+                } else if (compare == 0) {
+                    minValues.add(t);
+                }
+            }
+        }
+        return minValues;
+    }
+
+    /**
+     * Determines if two floats are close enough to be considered "equal" (difference < 1e-6)
+     * @param a first float
+     * @param b second float
+     * @return true if the floats are close
+     */
+    public static boolean isClose(float a, float b) {
+        return Math.abs(a - b) < 1e-6;
     }
 
     public static boolean isInt(String string) {

--- a/src/main/resources/config-langs/en.yml
+++ b/src/main/resources/config-langs/en.yml
@@ -57,6 +57,12 @@ config:
     Always show that a brew is alcoholic by putting "Alcoholic" in the item's lore
     Sealed brews will show that a brew is alcoholic, but not its alcohol content
   showBrewer: "If we should show who brewed the drink [false]"
+  showRuinedBrewHints: |
+    If ruined brews show hints about why they were ruined [false].
+    Examples:
+    - "Too much time in the oven..."
+    - "One of the ingredients doesn't taste good..."
+    Note that the hints are for the closest recipe based on the ingredients and may not be 100% accurate.
   requireKeywordOnSigns: "If barrels are only created when the sign placed contains the word \"barrel\" (or a translation when using another language) [true]"
   ageInMCBarrels: "If aging in -Minecraft- Barrels in enabled [true] and how many Brewery drinks can be put into them [6]"
   agingYearDuration: "Duration (in minutes) of a 'year' when aging drinks [20]"

--- a/src/main/resources/languages/en.yml
+++ b/src/main/resources/languages/en.yml
@@ -2,7 +2,7 @@
 # Author: DieReicheEtherons
 # Brew
 Brew_-times: -times
-Brew_BadPotion: Ruined Potion
+Brew_BadPotion: Ruined Brew
 Brew_BarrelRiped: Barrel aged
 Brew_DistillUndefined: Murky Distillate
 Brew_Distilled: Distilled
@@ -51,6 +51,45 @@ CMD_Invalid_Ingredient: '&c"&v1" is not a valid ingredient, did you mean "&v2/&v
 CMD_Cannot_Distill: '&cThose ingredients cannot be distilled'
 CMD_Distill_Ruined: '&eThe brew was ruined in the distillation process'
 CMD_Age_Ruined: '&eThe brew was ruined in the aging process'
+
+# Defects
+Defect_WrongIngredient:
+  - 'There''s something in here that shouldn''t be in here...'
+  - 'One of the ingredients doesn''t taste good...'
+Defect_MissingIngredient:
+  - 'Seems like something''s missing...'
+  - 'Needs something more...'
+Defect_LowCount:
+  - 'You can barely taste one of the ingredients...'
+  - 'The flavor of one of the ingredients is too weak...'
+Defect_HighCount:
+  - 'One of the ingredients is overpowering...'
+  - 'The flavor of one of the ingredients is too strong...'
+Defect_NeedsDistill:
+  - 'You can''t taste the alcohol...'
+  - 'This needs some distillation...'
+Defect_BadDistill:
+  - 'The brew evaporated...'
+  - 'This definitely didn''t need distillation...'
+Defect_Uncooked:
+  - 'It''s still raw...'
+  - 'Not enough time in the oven...'
+Defect_Overcooked:
+  - 'It''s burnt...'
+  - 'Too much time in the oven...'
+Defect_UnderAged:
+  - 'This needs fermentation...'
+  - 'Not enough time in the barrel...'
+Defect_OverAged:
+  - 'This brew smells expired...'
+  - 'This brew is ancient...'
+Defect_BadAged:
+  - 'This brew shouldn''t have been aged...'
+Defect_WrongWood:
+  - 'Tastes too much like &v1...'
+  - 'The &v1 is overpowering...'
+Defect_NoRecipesRegistered:
+  - 'This universe doesn''t support brewing...'
 
 # Error
 Error_ConfigUpdate: 'Unknown Brewery config version: v&v1, config was not updated!'


### PR DESCRIPTION
When trying to create a brew through trial and error, it can be frustrating to try all sorts of combinations without any feedback other than a "Ruined Potion". This PR adds a config option `showRuinedBrewHints` that shows messages on completely ruined brews, hinting at how not to ruin them next time.

Examples hints include:
- "Too much time in the oven..."
- "One of the ingredients is overpowering..."

![image](https://github.com/user-attachments/assets/992cc6b2-8423-4a97-94c6-2fb3cbea52ec)

When the plugin calculates a brew's quality based on the ingredients, the plugin also tracks deductions in quality due to defects (such as an ingredient that doesn't belong) and fatal issues that prevent a recipe from being made at all (such as when a recipe needs distilling). The recipe that has the least severe issues is what the player was *probably* trying to make, so the player will see a hint based on the worst defect for that recipe. This method is not foolproof (finding the best recipe isn't foolproof either), but from player feedback, the hints are useful in the majority of cases.

Ruined brew hints are off by default so the difficulty of brewing drinks does not change. I encourage turning it on though, my players told me that this feature made trying different combinations for drinks much more enjoyable (BreweryNG has a similar feature).

Regardless of whether `showRuinedBrewHints` is enabled, `/brew debuginfo` now also logs all defects for each recipe, helping to narrow down why a particular recipe isn't being selected.
