### PR TITLE
Fix/folia reload

### DIFF
--- a/src/main/java/com/dre/brewery/BCauldron.java
+++ b/src/main/java/com/dre/brewery/BCauldron.java
@@ -527,14 +527,18 @@ public class BCauldron {
      * Recalculate the Cauldron Particle Recipe
      */
     public static void reload() {
+        var scheduler = BreweryPlugin.getScheduler();
         for (BCauldron cauldron : bcauldrons.values()) {
             cauldron.particleRecipe = null;
             cauldron.particleColor = null;
-            if (config.isEnableCauldronParticles()) {
-                if (BUtil.isChunkLoaded(cauldron.block) && MaterialUtil.isCauldronHeatSource(cauldron.block.getRelative(BlockFace.DOWN))) {
-                    cauldron.getParticleColor();
+
+            scheduler.execute(cauldron.block.getLocation(), () -> {
+                if (config.isEnableCauldronParticles()) {
+                    if (BUtil.isChunkLoaded(cauldron.block) && MaterialUtil.isCauldronHeatSource(cauldron.block.getRelative(BlockFace.DOWN))) {
+                        cauldron.getParticleColor();
+                    }
                 }
-            }
+            });
         }
     }
 

--- a/src/main/java/com/dre/brewery/BCauldron.java
+++ b/src/main/java/com/dre/brewery/BCauldron.java
@@ -527,16 +527,18 @@ public class BCauldron {
      * Recalculate the Cauldron Particle Recipe
      */
     public static void reload() {
+        if (!config.isEnableCauldronParticles()) {
+            return;
+        }
+        
         var scheduler = BreweryPlugin.getScheduler();
         for (BCauldron cauldron : bcauldrons.values()) {
             cauldron.particleRecipe = null;
             cauldron.particleColor = null;
 
             scheduler.execute(cauldron.block.getLocation(), () -> {
-                if (config.isEnableCauldronParticles()) {
-                    if (BUtil.isChunkLoaded(cauldron.block) && MaterialUtil.isCauldronHeatSource(cauldron.block.getRelative(BlockFace.DOWN))) {
-                        cauldron.getParticleColor();
-                    }
+                if (BUtil.isChunkLoaded(cauldron.block) && MaterialUtil.isCauldronHeatSource(cauldron.block.getRelative(BlockFace.DOWN))) {
+                    cauldron.getParticleColor();
                 }
             });
         }


### PR DESCRIPTION
Fixes #120 

The problem is the reload command getting called in an async context on DataManagerCommand#execute at line 46
Folia has a stricter policy to access block data async so it throws.