### PR TITLE
fix: executing commands on the wrong thread with folia

### DIFF
--- a/src/main/java/com/dre/brewery/recipe/BRecipe.java
+++ b/src/main/java/com/dre/brewery/recipe/BRecipe.java
@@ -563,11 +563,14 @@ public class BRecipe implements Cloneable {
 
     private void executeCommand(Player player, String cmd, String playerName, int quality, boolean isServerCommand) {
         String finalCommand = PlaceholderAPIHook.PLACEHOLDERAPI.setPlaceholders(player, BUtil.applyPlaceholders(cmd, playerName, quality));
-        if (isServerCommand) {
-            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), finalCommand);
-        } else {
-            Bukkit.dispatchCommand(player, finalCommand);
-        }
+        BreweryPlugin.getScheduler().execute(() -> {
+                if (isServerCommand) {
+                    Bukkit.dispatchCommand(Bukkit.getConsoleSender(), finalCommand);
+                } else {
+                    Bukkit.dispatchCommand(player, finalCommand);
+                }
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
Fix an issue on Folia servers where executing commands after drinking wine would throw:
brewery java.lang.IllegalStateException: Dispatching command async
#164