### PR TITLE
fix(barrel): preserve data across world reloads

### DIFF
--- a/src/main/java/com/dre/brewery/Barrel.java
+++ b/src/main/java/com/dre/brewery/Barrel.java
@@ -460,6 +460,7 @@ public class Barrel extends BarrelBody implements InventoryHolder {
         BarrelRemoveEvent event = new BarrelRemoveEvent(this, dropItems);
         // Listened to by LWCBarrel (IntegrationListener)
         BreweryPlugin.getInstance().getServer().getPluginManager().callEvent(event);
+        BreweryPlugin.getDataManager().deleteBarrel(id);
 
         if (inventory != null) {
             List<HumanEntity> viewers = new ArrayList<>(inventory.getViewers());
@@ -599,7 +600,10 @@ public class Barrel extends BarrelBody implements InventoryHolder {
                 .forEach(worldUuid -> {
                     // Folia doesn't fire 'WorldUnloadEvent' but Canvas does.
                     if (MinecraftVersion.isFolia() && !MinecraftVersion.isCanvas() && Bukkit.getWorld(worldUuid) == null) {
-                        barrels.remove(worldUuid); // remove this world and assume that it was unloaded on Folia servers
+                        List<Barrel> unloadedBarrels = barrels.remove(worldUuid);
+                        if (unloadedBarrels != null) {
+                            unloadedBarrels.forEach(BreweryPlugin.getDataManager()::saveBarrel);
+                        }
                         return;
                     }
 

--- a/src/main/java/com/dre/brewery/BreweryPlugin.java
+++ b/src/main/java/com/dre/brewery/BreweryPlugin.java
@@ -47,6 +47,7 @@ import com.dre.brewery.listeners.CauldronListener;
 import com.dre.brewery.listeners.EntityListener;
 import com.dre.brewery.listeners.InventoryListener;
 import com.dre.brewery.listeners.PlayerListener;
+import com.dre.brewery.listeners.WorldListener;
 import com.dre.brewery.recipe.CustomItem;
 import com.dre.brewery.recipe.Ingredient;
 import com.dre.brewery.recipe.ItemLoader;
@@ -225,6 +226,7 @@ public final class BreweryPlugin extends JavaPlugin {
         pluginManager.registerEvents(new EntityListener(), this);
         pluginManager.registerEvents(new InventoryListener(), this);
         pluginManager.registerEvents(new IntegrationListener(), this);
+        pluginManager.registerEvents(new WorldListener(dataManager), this);
         if (getMCVersion().isOrLater(MinecraftVersion.V1_9))
             pluginManager.registerEvents(new CauldronListener(), this);
         if (Hook.CHESTSHOP.isEnabled() && getMCVersion().isOrLater(MinecraftVersion.V1_13))

--- a/src/main/java/com/dre/brewery/listeners/WorldListener.java
+++ b/src/main/java/com/dre/brewery/listeners/WorldListener.java
@@ -28,19 +28,23 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.world.WorldLoadEvent;
 import org.bukkit.event.world.WorldUnloadEvent;
 
+import java.util.Objects;
+
 public record WorldListener(DataManager dataManager) implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onWorldLoad(WorldLoadEvent event) {
         dataManager.getAllBarrels()
             .thenAcceptAsync(barrels -> barrels.stream()
+                .filter(Objects::nonNull)
                 .filter(barrel -> barrel.getSpigot().getWorld().equals(event.getWorld()))
                 .forEach(Barrel::registerBarrel)
             );
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
-    public void onWorldLoad(WorldUnloadEvent event) {
+    public void onWorldUnload(WorldUnloadEvent event) {
+        Barrel.getBarrels(event.getWorld().getUID()).forEach(dataManager::saveBarrel);
         Barrel.onUnload(event.getWorld());
     }
 }

--- a/src/main/java/com/dre/brewery/storage/DataManager.java
+++ b/src/main/java/com/dre/brewery/storage/DataManager.java
@@ -194,7 +194,9 @@ public abstract class DataManager {
 
     private void doSave(Collection<Barrel> barrels, Collection<BCauldron> cauldrons, Collection<BPlayer> players, Collection<Wakeup> wakeups) {
         this.saveBreweryMiscData(getLoadedMiscData());
-        this.saveAllBarrels(barrels);
+        // Barrels from unloaded worlds are intentionally absent from the in-memory registry. Upsert
+        // loaded barrels instead of deleting every stored barrel that is not currently in memory.
+        barrels.forEach(this::saveBarrel);
         this.saveAllCauldrons(cauldrons);
         this.saveAllPlayers(players);
         this.saveAllWakeups(wakeups);


### PR DESCRIPTION
## Summary
- register the existing world load/unload listener
- reload persisted barrels when a world becomes available
- save and unregister barrels when their world unloads
- preserve unloaded-world barrel rows during autosaves
- explicitly delete persisted rows when a barrel is actually destroyed
- preserve Folia barrel data when detecting an unloaded world without an unload event

This replaces the debug-only approach in #198 with the actual fix.

Fixes #197.

## Testing
- `./gradlew compileJava --console=plain --no-daemon`