### PR TITLE
Add Dominion barrel protection integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,6 +117,7 @@ dependencies {
     compileOnly("com.acrobot.chestshop:chestshop:3.12.2") // https://github.com/ChestShop-authors/ChestShop-3/releases
     compileOnly("com.palmergames.bukkit.towny:towny:0.100.3.0") // https://www.spigotmc.org/resources/towny-advanced.72694/history
     compileOnly("com.github.Angeschossen:LandsAPI:7.11.10") // https://www.spigotmc.org/resources/lands.53313/history
+    compileOnly("cn.lunadeer:DominionAPI:4.8.3") // https://github.com/LunaDeerMC/DominionAPI
     compileOnly("com.nisovin.shopkeepers:ShopkeepersAPI:2.18.0") // https://www.spigotmc.org/resources/shopkeepers.80756/history
     compileOnly("nl.rutgerkok:blocklocker:1.10.4") // https://www.spigotmc.org/resources/blocklocker.3268/history
     compileOnly("me.clip:placeholderapi:2.11.5") // https://www.spigotmc.org/resources/placeholderapi.6245/history

--- a/src/main/java/com/dre/brewery/configuration/files/Config.java
+++ b/src/main/java/com/dre/brewery/configuration/files/Config.java
@@ -188,6 +188,7 @@ public class Config extends AbstractOkaeriConfigFile {
     private boolean useGriefPrevention = true;
     private boolean useTowny = true;
     private boolean useLands = true;
+    private boolean useDominion = true;
     private boolean useBlockLocker = true;
     private boolean useGMInventories = true;
 

--- a/src/main/java/com/dre/brewery/integration/Hook.java
+++ b/src/main/java/com/dre/brewery/integration/Hook.java
@@ -41,6 +41,7 @@ public class Hook {
     public static final Hook GRIEFPREVENTION = new Hook("GriefPrevention", config.isUseGriefPrevention());
     public static final Hook TOWNY = new Hook("Towny", config.isUseTowny());
     public static final Hook LANDS = new Hook("Lands", config.isUseLands());
+    public static final Hook DOMINION = new Hook("Dominion", config.isUseDominion());
     public static final Hook LOGBLOCK = new Hook("LogBlock", config.isUseLogBlock());
     public static final Hook GAMEMODEINVENTORIES = new Hook("GameModeInventories", config.isUseGMInventories());
     public static final Hook MMOITEMS = new Hook("MMOItems");

--- a/src/main/java/com/dre/brewery/integration/barrel/DominionBarrel.java
+++ b/src/main/java/com/dre/brewery/integration/barrel/DominionBarrel.java
@@ -1,0 +1,39 @@
+/*
+ * BreweryX Bukkit-Plugin for an alternate brewing process
+ * Copyright (C) 2024 The Brewery Team
+ *
+ * This file is part of BreweryX.
+ *
+ * BreweryX is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BreweryX is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BreweryX. If not, see <http://www.gnu.org/licenses/gpl-3.0.html>.
+ */
+
+package com.dre.brewery.integration.barrel;
+
+import cn.lunadeer.dominion.api.DominionAPI;
+import cn.lunadeer.dominion.api.dtos.flag.Flags;
+import com.dre.brewery.api.events.barrel.BarrelAccessEvent;
+
+public final class DominionBarrel {
+
+    private DominionBarrel() {
+    }
+
+    public static boolean checkAccess(BarrelAccessEvent event) {
+        DominionAPI api = DominionAPI.getInstance();
+        if (api == null) {
+            throw new IllegalStateException("Dominion API is not initialized");
+        }
+        return api.checkPrivilegeFlag(event.getSpigot().getLocation(), Flags.CONTAINER, event.getPlayer());
+    }
+}

--- a/src/main/java/com/dre/brewery/integration/listeners/IntegrationListener.java
+++ b/src/main/java/com/dre/brewery/integration/listeners/IntegrationListener.java
@@ -33,6 +33,7 @@ import com.dre.brewery.integration.BlockLockerHook;
 import com.dre.brewery.integration.Hook;
 import com.dre.brewery.integration.WorldGuarkHook;
 import com.dre.brewery.integration.barrel.BlockLockerBarrel;
+import com.dre.brewery.integration.barrel.DominionBarrel;
 import com.dre.brewery.integration.barrel.GriefPreventionBarrel;
 import com.dre.brewery.integration.barrel.LWCBarrel;
 import com.dre.brewery.integration.barrel.LandsBarrel;
@@ -203,6 +204,28 @@ public class IntegrationListener implements Listener {
             if (!LandsBarrel.checkAccess(event)) {
                 lang.sendEntry(event.getPlayer(), "Error_NoBarrelAccess");
                 event.setCancelled(true);
+                return;
+            }
+        }
+
+        if (Hook.DOMINION.isEnabled()) {
+            try {
+                if (!DominionBarrel.checkAccess(event)) {
+                    event.setCancelled(true);
+                    return;
+                }
+            } catch (Throwable e) {
+                event.setCancelled(true);
+                Logging.errorLog("Failed to check Dominion for barrel open permissions!", e);
+                Logging.errorLog("Brewery was tested with Dominion API v4.8.3");
+                Logging.errorLog("Disable Dominion support in the config and do /brew reload");
+                Player player = event.getPlayer();
+                if (player.hasPermission("brewery.admin") || player.hasPermission("brewery.mod")) {
+                    Logging.msg(player, "&cDominion check error, Brewery was tested with Dominion API v4.8.3");
+                    Logging.msg(player, "&cSet &7useDominion: false &cin the config and /brew reload");
+                } else {
+                    Logging.msg(player, "&cError opening Barrel, please report to an Admin!");
+                }
                 return;
             }
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -15,6 +15,7 @@ softdepend:
   - Shopkeepers
   - Towny
   - Lands
+  - Dominion
   - BlockLocker
   - Slimefun
   - PlaceholderAPI


### PR DESCRIPTION
## Summary
- add Dominion as an optional dependency and configurable integration
- check Dominion's built-in `CONTAINER` privilege before opening BreweryX barrels
- respect Dominion world-wide privilege rules and native denial handling
- fail closed with actionable logs if the optional API is incompatible

## Verification
- `./gradlew compileJava --stacktrace`

Closes #221.

Also addresses LunaDeerMC/Dominion#262.