### PR TITLE
Fix sealer inventory race on Folia

### DIFF
--- a/src/main/java/com/dre/brewery/BSealer.java
+++ b/src/main/java/com/dre/brewery/BSealer.java
@@ -88,7 +88,7 @@ public class BSealer implements InventoryHolder {
     public void clickInv() {
         contents = null;
         if (task == null) {
-            task = BreweryPlugin.getScheduler().runTaskTimer(BreweryPlugin.getInstance(), this::itemChecking, 1, 1);
+            task = BreweryPlugin.getScheduler().runTaskTimer(player, this::itemChecking, 1, 1);
         }
     }
 


### PR DESCRIPTION
## Summary
- schedule each sealing-table check on its owning player's entity scheduler
- keep inventory clicks, closes, and sealing checks in the same Folia execution context
- prevent the reported `BSealer.itemChecking` null race caused by a global-region task

## Verification
- `./gradlew compileJava`

Closes #219.