### PR TITLE
Fix SHORT_GRASS linkage on Minecraft 1.20.2

### DIFF
--- a/src/main/java/com/dre/brewery/configuration/sector/CauldronSector.java
+++ b/src/main/java/com/dre/brewery/configuration/sector/CauldronSector.java
@@ -21,6 +21,7 @@
 package com.dre.brewery.configuration.sector;
 
 import com.dre.brewery.configuration.sector.capsule.ConfigCauldronIngredient;
+import com.dre.brewery.utility.BukkitConstants;
 import eu.okaeri.configs.annotation.Comment;
 import lombok.Getter;
 import lombok.Setter;
@@ -82,7 +83,7 @@ public class CauldronSector extends AbstractOkaeriConfigSector<ConfigCauldronIng
 
     ConfigCauldronIngredient grass = ConfigCauldronIngredient.builder()
         .name("Boiled herbs")
-        .ingredients(List.of(Material.SHORT_GRASS.name()))
+        .ingredients(List.of(BukkitConstants.SHORT_GRASS.name()))
         .color("99ff66")
         .cookParticles(List.of("GREEN/2", "99ff99/20"))
         .build();
@@ -229,7 +230,7 @@ public class CauldronSector extends AbstractOkaeriConfigSector<ConfigCauldronIng
 
     ConfigCauldronIngredient poi_grass = ConfigCauldronIngredient.builder()
         .name("Boiled acidy herbs")
-        .ingredients(List.of(Material.SHORT_GRASS.name(), Material.POISONOUS_POTATO.name()))
+        .ingredients(List.of(BukkitConstants.SHORT_GRASS.name(), Material.POISONOUS_POTATO.name()))
         .color("99ff66")
         .cookParticles(List.of("GREEN/2", "99ff99/20"))
         .build();

--- a/src/main/java/com/dre/brewery/configuration/sector/RecipesSector.java
+++ b/src/main/java/com/dre/brewery/configuration/sector/RecipesSector.java
@@ -241,7 +241,7 @@ public class RecipesSector extends AbstractOkaeriConfigSector<ConfigRecipe> {
 
     ConfigRecipe absinthe = ConfigRecipe.builder()
         .name("Poor Absinthe/Absinthe/Strong Absinthe")
-        .ingredients(List.of(Material.SHORT_GRASS.name() + "/15"))
+        .ingredients(List.of(BukkitConstants.SHORT_GRASS.name() + "/15"))
         .cookingTime(3)
         .distillRuns(6)
         .distillTime(80)
@@ -254,7 +254,7 @@ public class RecipesSector extends AbstractOkaeriConfigSector<ConfigRecipe> {
 
     ConfigRecipe gr_absinthe = ConfigRecipe.builder()
         .name("Poor Absinthe/Green Absinthe/Bright Green Absinthe")
-        .ingredients(List.of(Material.SHORT_GRASS.name() + "/17", Material.POISONOUS_POTATO.name() + "/2"))
+        .ingredients(List.of(BukkitConstants.SHORT_GRASS.name() + "/17", Material.POISONOUS_POTATO.name() + "/2"))
         .cookingTime(5)
         .distillRuns(6)
         .distillTime(85)
@@ -267,7 +267,7 @@ public class RecipesSector extends AbstractOkaeriConfigSector<ConfigRecipe> {
 
     ConfigRecipe potato_soup = ConfigRecipe.builder()
         .name("Potato soup")
-        .ingredients(List.of(Material.POTATO.name() + "/5", Material.SHORT_GRASS.name() + "/3"))
+        .ingredients(List.of(Material.POTATO.name() + "/5", BukkitConstants.SHORT_GRASS.name() + "/3"))
         .cookingTime(3)
         .color("ORANGE")
         .difficulty(1)

--- a/src/main/java/com/dre/brewery/storage/BData.java
+++ b/src/main/java/com/dre/brewery/storage/BData.java
@@ -33,6 +33,7 @@ import com.dre.brewery.lore.Base91DecoderStream;
 import com.dre.brewery.recipe.Ingredient;
 import com.dre.brewery.recipe.SimpleItem;
 import com.dre.brewery.utility.BUtil;
+import com.dre.brewery.utility.BukkitConstants;
 import com.dre.brewery.utility.BoundingBox;
 import com.dre.brewery.utility.FutureUtil;
 import com.dre.brewery.utility.Logging;
@@ -258,7 +259,7 @@ public class BData {
             Material m = Material.getMaterial(matSplit[0]);
             if (m == null && VERSION.isOrLater(MinecraftVersion.V1_13)) {
                 if (matSplit[0].equals("LONG_GRASS")) {
-                    m = Material.SHORT_GRASS;
+                    m = BukkitConstants.SHORT_GRASS;
                 } else {
                     m = Material.matchMaterial(matSplit[0], true);
                 }


### PR DESCRIPTION
## Summary
- use BreweryX's version-aware grass material in default cauldron ingredients and recipes
- use the same compatibility constant while migrating legacy `LONG_GRASS` data
- avoid linking `Material.SHORT_GRASS`, which is absent from the supported 1.20.2 API

## Verification
- `./gradlew compileJava`
- inspected generated bytecode for the affected classes; none reference `Material.SHORT_GRASS`
- verified against the official Spigot 1.20.2 API artifact that `SHORT_GRASS` is absent

Closes #201.